### PR TITLE
Add reusable advice email button and payload builder

### DIFF
--- a/components/AdviceEmailButton.js
+++ b/components/AdviceEmailButton.js
@@ -1,0 +1,124 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Platform,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  TouchableOpacity,
+} from 'react-native';
+import { sendAdviceByEmail } from '../utils/sendAdviceByEmail';
+
+const DEFAULT_LABEL = 'Verstuur advies per e-mail';
+
+const showSuccessMessage = (message) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  } else {
+    Alert.alert('Succes', message);
+  }
+};
+
+const showFallbackMessage = (message) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  } else {
+    Alert.alert('Let op', message);
+  }
+};
+
+const showErrorMessage = (errorMessage) => {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(errorMessage, ToastAndroid.LONG);
+  } else {
+    Alert.alert('Verzenden mislukt', errorMessage);
+  }
+};
+
+export default function AdviceEmailButton({
+  payload,
+  label = DEFAULT_LABEL,
+  style,
+  textStyle,
+  onSuccess,
+  onError,
+}) {
+  const [loading, setLoading] = useState(false);
+
+  const disabled = useMemo(() => loading || !payload, [loading, payload]);
+
+  const handlePress = useCallback(async () => {
+    if (!payload || loading) {
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const result = await sendAdviceByEmail(payload, {
+        onComposerOpen: () =>
+          showSuccessMessage('De e-mail wordt klaargezet in je standaard mail-app.'),
+      });
+
+      if (result?.method === 'share') {
+        showFallbackMessage('Mailen is niet beschikbaar. We openen de deelopties.');
+      } else if (result?.method === 'mailto') {
+        showFallbackMessage('Mailcomposer ontbreekt. We openen een mailto-link.');
+      }
+
+      if (onSuccess) {
+        onSuccess(result);
+      }
+    } catch (error) {
+      console.error('AdviceEmailButton: sendAdviceByEmail failed', error);
+      showErrorMessage(
+        error?.message || 'Het versturen van het advies is niet gelukt. Probeer het opnieuw.'
+      );
+
+      if (onError) {
+        onError(error);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, onError, onSuccess, payload]);
+
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      activeOpacity={0.8}
+      onPress={handlePress}
+      disabled={disabled}
+      style={[styles.button, disabled && styles.buttonDisabled, style]}
+    >
+      {loading ? (
+        <ActivityIndicator color="#fff" />
+      ) : (
+        <Text style={[styles.label, textStyle]}>{label}</Text>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: '#f7941e',
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    marginTop: 16,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  label: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,17 @@
       "license": "0BSD",
       "dependencies": {
         "@expo/metro-runtime": "~5.0.4",
+        "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/masked-view": "^0.1.11",
         "@react-native-masked-view/masked-view": "^0.3.2",
         "@react-navigation/native": "^7.1.9",
         "@react-navigation/native-stack": "^7.3.13",
-        "expo": "~53.0.9",
+        "expo": "54.0.0",
         "expo-dev-client": "~5.2.0",
-        "expo-mail-composer": "~15.0.1",
+        "expo-modules-core": "~3.0.15",
         "expo-status-bar": "~2.2.3",
         "expo-updates": "~0.28.14",
-        "glob": "^11.0.3",
+        "firebase": "^12.0.0",
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.2",
@@ -27,8 +28,8 @@
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.10.0",
-        "react-native-web": "^0.20.0",
-        "rimraf": "^6.0.1"
+        "react-native-toast-message": "^2.3.3",
+        "react-native-web": "^0.20.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -1356,6 +1357,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1677,13 +1679,13 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "11.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-11.0.11.tgz",
-      "integrity": "sha512-jUPFrayUhSCHrDu8bc69oQ/wBST2HmozbIiCi4vBQ2Mh+UQSCg4e4EwzjDz9K0MNU+YMS+YWS76SvdGVlCWKaw==",
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-11.0.10.tgz",
+      "integrity": "sha512-8S8Krr/c5lnl0eF03tA2UGY9rGBhZcbWKz2UWw5dpL/+zstwUmog8oyuuC8aRcn7GiTQLlbBkxcMeT8sOGlhbA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~10.0.3",
+        "@expo/config-plugins": "~10.0.2",
         "@expo/config-types": "^53.0.4",
         "@expo/json-file": "^9.1.4",
         "deepmerge": "^4.3.1",
@@ -1698,12 +1700,12 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.0.3.tgz",
-      "integrity": "sha512-fjCckkde67pSDf48x7wRuPsgQVIqlDwN7NlOk9/DFgQ1hCH0L5pGqoSmikA1vtAyiA83MOTpkGl3F3wyATyUog==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.0.2.tgz",
+      "integrity": "sha512-TzUn3pPdpwCS0yYaSlZOClgDmCX8N4I2lfgitX5oStqmvpPtB+vqtdyqsVM02fQ2tlJIAqwBW+NHaHqqy8Jv7g==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^53.0.4",
+        "@expo/config-types": "^53.0.3",
         "@expo/json-file": "~9.1.4",
         "@expo/plist": "^0.3.4",
         "@expo/sdk-runtime-versions": "^1.0.0",
@@ -1789,9 +1791,9 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "53.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-53.0.4.tgz",
-      "integrity": "sha512-0s+9vFx83WIToEr0Iwy4CcmiUXa5BgwBmEjylBB2eojX5XAMm9mJvw9KpjAb8m7zq2G0Q6bRbeufkzgbipuNQg==",
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
+      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
       "license": "MIT"
     },
     "node_modules/@expo/config/node_modules/@babel/code-frame": {
@@ -1892,11 +1894,11 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/@expo/devcert/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
+    "node_modules/@expo/devtools": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@expo/devtools/-/devtools-0.1.6.tgz",
+      "integrity": "sha512-NE4TaCyUS/Cy2YxMdajt4grjfuJIsv6symUbQXk06Y96SyHy5DVzI1H0KdUca1HkPoZwwGCACFZZCN+Jvzuujw==",
+      "license": "MIT",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -1985,61 +1987,13 @@
         "fingerprint": "bin/cli.js"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/@expo/fingerprint/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
+    "node_modules/@expo/fingerprint/node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=6"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/semver": {
@@ -2084,9 +2038,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.1.4.tgz",
-      "integrity": "sha512-7Bv86X27fPERGhw8aJEZvRcH9sk+9BenDnEmrI3ZpywKodYSBgc8lX9Y32faNVQ/p0YbDK9zdJ0BfAKNAOyi0A==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
+      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
@@ -2103,18 +2057,17 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.20.15",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.20.15.tgz",
-      "integrity": "sha512-m8i58IQ7I8iOdVRfOhFmhPMHuhgeTVfQp1+mxW7URqPZaeVbuDVktPqOiNoHraKBoGPLKMUSsD+qdUuJVL3wMg==",
+      "version": "54.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.0.tgz",
+      "integrity": "sha512-i/1qAVXNaqOPNKBC6QIiiR2V0KsT+QTPxjDbsp8Tm5a6njNwUD9e0LyS84VM1h3SJf8n0uCKFQrQNL5kx5+LRA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@babel/parser": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "@expo/config": "~11.0.10",
-        "@expo/env": "~1.0.5",
-        "@expo/json-file": "~9.1.4",
+        "@expo/config": "~12.0.7",
+        "@expo/env": "~2.0.6",
+        "@expo/json-file": "~10.0.6",
+        "@expo/metro": "~0.1.1",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
@@ -2127,72 +2080,458 @@
         "minimatch": "^9.0.0",
         "postcss": "~8.4.32",
         "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@expo/metro-config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+    "node_modules/@expo/metro-config/node_modules/@expo/config": {
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.8.tgz",
+      "integrity": "sha512-yFadXa5Cmja57EVOSyEYV1hF7kCaSbPnd1twx0MfvTr1Yj2abIbrEu2MUZqcvElNQOtgADnLRP0YJiuEdgoO5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~54.0.0",
+        "@expo/config-types": "^54.0.7",
+        "@expo/json-file": "^10.0.7",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.35.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/config-plugins": {
+      "version": "54.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.1.tgz",
+      "integrity": "sha512-NyBChhiWFL6VqSgU+LzK4R1vC397tEG2XFewVt4oMr4Pnalq/mJxBANQrR+dyV1RHhSyhy06RNiJIkQyngVWeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "~10.0.7",
+        "@expo/plist": "^0.4.7",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/config-types": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
+      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
+      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/plist": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-estree": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-parser": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.29.1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
       "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/@expo/metro-config/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "semver": "bin/semver.js"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
     "node_modules/@expo/metro-runtime": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-5.0.4.tgz",
-      "integrity": "sha512-r694MeO+7Vi8IwOsDIDzH/Q5RPMt1kUDYbiTJwnO15nIqiDwlE8HU55UlRhffKZy6s5FmxQsZ8HA+T8DqUW8cQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-6.1.1.tgz",
+      "integrity": "sha512-H5ZFj7nisMJ5a4joMGpF4Xt/m4hWDAroMNv5ld/2iniWoXLvNt+YQpMdyecu/lHpydKAjHzXcyE08hTGgURaIA==",
       "license": "MIT",
+      "dependencies": {
+        "anser": "^1.4.9",
+        "pretty-format": "^29.7.0",
+        "stacktrace-parser": "^0.1.10",
+        "whatwg-fetch": "^3.0.0"
+      },
       "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-dom": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro/node_modules/hermes-estree": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro/node_modules/hermes-parser": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.29.1"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.1.tgz",
+      "integrity": "sha512-UGKepmTxoGD4HkQV8YWvpvwef7fUujNtTgG4Ygf7m/M0qjvb9VuDmAsEU+UdriRX7F61pnVK/opz89hjKlYTXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.24.7",
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.3",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.3",
+        "@babel/types": "^7.25.2",
+        "accepts": "^1.3.7",
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "error-stack-parser": "^2.0.6",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "hermes-parser": "0.29.1",
+        "image-size": "^1.0.2",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "jsc-safe-url": "^0.2.2",
+        "lodash.throttle": "^4.1.1",
+        "metro-babel-transformer": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-cache-key": "0.83.1",
+        "metro-config": "0.83.1",
+        "metro-core": "0.83.1",
+        "metro-file-map": "0.83.1",
+        "metro-resolver": "0.83.1",
+        "metro-runtime": "0.83.1",
+        "metro-source-map": "0.83.1",
+        "metro-symbolicate": "0.83.1",
+        "metro-transform-plugins": "0.83.1",
+        "metro-transform-worker": "0.83.1",
+        "mime-types": "^2.1.27",
+        "nullthrows": "^1.1.1",
+        "serialize-error": "^2.1.0",
+        "source-map": "^0.5.6",
+        "throat": "^5.0.0",
+        "ws": "^7.5.10",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "metro": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-babel-transformer": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.1.tgz",
+      "integrity": "sha512-r3xAD3964E8dwDBaZNSO2aIIvWXjIK80uO2xo0/pi3WI8XWT9h5SCjtGWtMtE5PRWw+t20TN0q1WMRsjvhC1rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-parser": "0.29.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-cache": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.1.tgz",
+      "integrity": "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "exponential-backoff": "^3.1.1",
+        "flow-enums-runtime": "^0.0.6",
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.83.1"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-cache-key": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.1.tgz",
+      "integrity": "sha512-ZUs+GD5CNeDLxx5UUWmfg26IL+Dnbryd+TLqTlZnDEgehkIa11kUSvgF92OFfJhONeXzV4rZDRGNXoo6JT+8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-config": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.1.tgz",
+      "integrity": "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA==",
+      "license": "MIT",
+      "dependencies": {
+        "connect": "^3.6.5",
+        "cosmiconfig": "^5.0.5",
+        "flow-enums-runtime": "^0.0.6",
+        "jest-validate": "^29.7.0",
+        "metro": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-core": "0.83.1",
+        "metro-runtime": "0.83.1"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-core": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.1.tgz",
+      "integrity": "sha512-uVL1eAJcMFd2o2Q7dsbpg8COaxjZBBGaXqO2OHnivpCdfanraVL8dPmY6It9ZeqWLOihUKZ2yHW4b6soVCzH/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "lodash.throttle": "^4.1.1",
+        "metro-resolver": "0.83.1"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-file-map": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.1.tgz",
+      "integrity": "sha512-Yu429lnexKl44PttKw3nhqgmpBR+6UQ/tRaYcxPeEShtcza9DWakCn7cjqDTQZtWR2A8xSNv139izJMyQ4CG+w==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fb-watchman": "^2.0.0",
+        "flow-enums-runtime": "^0.0.6",
+        "graceful-fs": "^4.2.4",
+        "invariant": "^2.2.4",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "nullthrows": "^1.1.1",
+        "walker": "^1.0.7"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-minify-terser": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.1.tgz",
+      "integrity": "sha512-kmooOxXLvKVxkh80IVSYO4weBdJDhCpg5NSPkjzzAnPJP43u6+usGXobkTWxxrAlq900bhzqKek4pBsUchlX6A==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "terser": "^5.15.0"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-resolver": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.1.tgz",
+      "integrity": "sha512-t8j46kiILAqqFS5RNa+xpQyVjULxRxlvMidqUswPEk5nQVNdlJslqizDm/Et3v/JKwOtQGkYAQCHxP1zGStR/g==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-runtime": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.1.tgz",
+      "integrity": "sha512-3Ag8ZS4IwafL/JUKlaeM6/CbkooY+WcVeqdNlBG0m4S0Qz0om3rdFdy1y6fYBpl6AwXJwWeMuXrvZdMuByTcRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-source-map": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.1.tgz",
+      "integrity": "sha512-De7Vbeo96fFZ2cqmI0fWwVJbtHIwPZv++LYlWSwzTiCzxBDJORncN0LcT48Vi2UlQLzXJg+/CuTAcy7NBVh69A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.25.3",
+        "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
+        "@babel/types": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-symbolicate": "0.83.1",
+        "nullthrows": "^1.1.1",
+        "ob1": "0.83.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-symbolicate": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.1.tgz",
+      "integrity": "sha512-wPxYkONlq/Sv8Ji7vHEx5OzFouXAMQJjpcPW41ySKMLP/Ir18SsiJK2h4YkdKpYrTS1+0xf8oqF6nxCsT3uWtg==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6",
+        "invariant": "^2.2.4",
+        "metro-source-map": "0.83.1",
+        "nullthrows": "^1.1.1",
+        "source-map": "^0.5.6",
+        "vlq": "^1.0.0"
+      },
+      "bin": {
+        "metro-symbolicate": "src/index.js"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-transform-plugins": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.1.tgz",
+      "integrity": "sha512-1Y+I8oozXwhuS0qwC+ezaHXBf0jXW4oeYn4X39XWbZt9X2HfjodqY9bH9r6RUTsoiK7S4j8Ni2C91bUC+sktJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/template": "^7.25.0",
+        "@babel/traverse": "^7.25.3",
+        "flow-enums-runtime": "^0.0.6",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/metro-transform-worker": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.1.tgz",
+      "integrity": "sha512-owCrhPyUxdLgXEEEAL2b14GWTPZ2zYuab1VQXcfEy0sJE71iciD7fuMcrngoufh7e7UHDZ56q4ktXg8wgiYA1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/generator": "^7.25.0",
+        "@babel/parser": "^7.25.3",
+        "@babel/types": "^7.25.2",
+        "flow-enums-runtime": "^0.0.6",
+        "metro": "0.83.1",
+        "metro-babel-transformer": "0.83.1",
+        "metro-cache": "0.83.1",
+        "metro-cache-key": "0.83.1",
+        "metro-minify-terser": "0.83.1",
+        "metro-source-map": "0.83.1",
+        "metro-transform-plugins": "0.83.1",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/@expo/metro/node_modules/ob1": {
+      "version": "0.83.1",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.1.tgz",
+      "integrity": "sha512-ngwqewtdUzFyycomdbdIhFLjePPSOt1awKMUXQ0L7iLHgWEPF3DsCerblzjzfAUHaXuvE9ccJymWQ/4PNNqvnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-enums-runtime": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=20.19.4"
       }
     },
     "node_modules/@expo/osascript": {
@@ -2223,9 +2562,9 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.3.4.tgz",
-      "integrity": "sha512-MhBLaUJNe9FQDDU2xhSNS4SAolr6K2wuyi4+A79vYuXLkAoICsbTwcGEQJN5jPY6D9izO/jsXh5k0h+mIWQMdw==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -2249,6 +2588,103 @@
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0",
         "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@expo/config": {
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.8.tgz",
+      "integrity": "sha512-yFadXa5Cmja57EVOSyEYV1hF7kCaSbPnd1twx0MfvTr1Yj2abIbrEu2MUZqcvElNQOtgADnLRP0YJiuEdgoO5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~54.0.0",
+        "@expo/config-types": "^54.0.7",
+        "@expo/json-file": "^10.0.7",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.35.0"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@expo/config-plugins": {
+      "version": "54.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.1.tgz",
+      "integrity": "sha512-NyBChhiWFL6VqSgU+LzK4R1vC397tEG2XFewVt4oMr4Pnalq/mJxBANQrR+dyV1RHhSyhy06RNiJIkQyngVWeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "~10.0.7",
+        "@expo/plist": "^0.4.7",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@expo/config-types": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
+      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@expo/json-file": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
+      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@expo/plist": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@react-native/normalize-colors": {
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.4.tgz",
+      "integrity": "sha512-9nRRHO1H+tcFqjb9gAM105Urtgcanbta2tuqCVY0NATHeFPDEAB7gPyiLxCHKMi1NbhP6TH0kxgSWXKZl1cyRg==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/prebuild-config/node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@expo/prebuild-config/node_modules/semver": {
@@ -2346,7 +2782,572 @@
         "@isaacs/balanced-match": "^4.0.1"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
+      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
+      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.0.tgz",
+      "integrity": "sha512-nUnNpOeRj0KZzVzHsyuyrmZKKHfykZ8mn40FtG28DeSTWeM5b/2P242Va4bmQpJsy5y32vfv50+jvdckrpzy7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
+      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.0.tgz",
+      "integrity": "sha512-J0lGSxXlG/lYVi45wbpPhcWiWUMXevY4fvLZsN1GHh+po7TZVng+figdHBVhFheaiipU8HZyc7ljw1jNojM2nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
+      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.11.tgz",
+      "integrity": "sha512-G258eLzAD6im9Bsw+Qm1Z+P4x0PGNQ45yeUuuqe5M9B1rn0RJvvsQCRHXgE52Z+n9+WX1OJd/crcuunvOGc7Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
+      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-types": "1.0.16",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
+      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.13.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.0.tgz",
+      "integrity": "sha512-5zl0+/h1GvlCSLt06RMwqFsd7uqRtnNZt4sW99k2rKRd6k/ECObIWlEnvthm2cuOSnUmwZknFqtmd1qyYSLUuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "@firebase/webchannel-wrapper": "1.0.4",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.0.tgz",
+      "integrity": "sha512-4O7v4VFeSEwAZtLjsaj33YrMHMRjplOIYC2CiYsF6o/MboOhrhe01VrTt8iY9Y5EwjRHuRz4pS6jMBT8LfQYJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/firestore": "4.9.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.0.tgz",
+      "integrity": "sha512-2/LH5xIbD8aaLOWSFHAwwAybgSzHIM0dB5oVOL0zZnxFG1LctX2bc1NIAaPk1T+Zo9aVkLKUlB5fTXTkVUQprQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.0.tgz",
+      "integrity": "sha512-VPgtvoGFywWbQqtvgJnVWIDFSHV1WE6Hmyi5EGI+P+56EskiGkmnw6lEqc/MEUfGpPGdvmc4I9XMU81uj766/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/functions": "0.13.0",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
+      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
+      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
+      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
+      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.8.tgz",
+      "integrity": "sha512-k6xfNM/CdTl4RaV4gT/lH53NU+wP33JiN0pUeNBzGVNvfXZ3HbCkoISE3M/XaiOwHgded1l6XfLHa4zHgm0Wyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.21.tgz",
+      "integrity": "sha512-OQfYRsIQiEf9ez1SOMLb5TRevBHNIyA2x1GI1H10lZ432W96AK5r4LTM+SNApg84dxOuHt6RWSQWY7TPWffKXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.8",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.6.tgz",
+      "integrity": "sha512-Yelp5xd8hM4NO1G1SuWrIk4h5K42mNwC98eWZ9YLVu6Z0S6hFk1mxotAdCRmH2luH8FASlYgLLq6OQLZ4nbnCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.19.tgz",
+      "integrity": "sha512-y7PZAb0l5+5oIgLJr88TNSelxuASGlXyAKj+3pUc4fDuRIdPNBoONMHaIUa9rlffBR5dErmaD2wUBJ7Z1a513Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.6.6",
+        "@firebase/remote-config-types": "0.4.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
+      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
+      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
+      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
+      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.4.tgz",
+      "integrity": "sha512-6m8+P+dE/RPl4OPzjTxcTbQ0rGeRyeTvAi9KwIffBVCiAMKrfXfLZaqD1F+m8t4B5/Q5aHsMozOgirkH1F5oMQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2634,9 +3635,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.9.tgz",
-      "integrity": "sha512-amBU75CKOOkcQLfyM6J+DnWwz41yTsWI7o8MQ003LwUIWb4NYX/evAblTx1oBBYJySqL/zHPxHXDw5ewpQaUFw==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2669,6 +3670,82 @@
         "node": ">=14"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.1.2.tgz",
+      "integrity": "sha512-dvlNq4AlGWC+ehtH12p65+17V0Dx7IecOWl6WanF2ja38O1Dcjjvn7jVzkUHJ5oWkQBlyASurTPlTHgKXyYiow==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-community/masked-view": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@react-native-community/masked-view/-/masked-view-0.1.11.tgz",
@@ -2691,12 +3768,12 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.2.tgz",
-      "integrity": "sha512-5h2Z7/+/HL/0h88s0JHOdRCW4CXMCJoROxqzHqxdrjGL6EBD1DdaB4ZqkCOEVSW4Vjhir5Qb97C8i/MPWEYPtg==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.81.4.tgz",
+      "integrity": "sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
@@ -2709,7 +3786,86 @@
         "@react-native/codegen": "0.79.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/@react-native/codegen": {
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.81.4.tgz",
+      "integrity": "sha512-LWTGUTzFu+qOQnvkzBP52B90Ym3stZT8IFCzzUrppz8Iwglg83FCtDZAR4yLHI29VY/x/+pkcWAMCl3739XHdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.25.3",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.29.1",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/hermes-estree": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/hermes-parser": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.29.1"
+      }
+    },
+    "node_modules/@react-native/babel-plugin-codegen/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@react-native/babel-preset": {
@@ -2772,19 +3928,21 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.4.tgz",
-      "integrity": "sha512-K0moZDTJtqZqSs+u9tnDPSxNsdxi5irq8Nu4mzzOYlJTVNGy5H9BiIDg/NeKGfjAdo43yTDoaPSbUCvVV8cgIw==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.2.tgz",
+      "integrity": "sha512-8JTlGLuLi1p8Jx2N/enwwEd7/2CfrqJpv90Cp77QLRX3VHF2hdyavRIxAmXMwN95k+Me7CUuPtqn2X3IBXOWYg==",
       "license": "MIT",
       "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.25.1",
+        "hermes-parser": "0.29.1",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "yargs": "^17.6.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
@@ -2821,6 +3979,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@react-native/codegen/node_modules/hermes-estree": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/codegen/node_modules/hermes-parser": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.29.1"
+      }
+    },
     "node_modules/@react-native/codegen/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2834,61 +4007,33 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.2.tgz",
-      "integrity": "sha512-E+YEY2dL+68HyR2iahsZdyBKBUi9QyPyaN9vsnda1jNgCjNpSPk2yAF5cXsho+zKK5ZQna3JSeE1Kbi2IfGJbw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.81.4.tgz",
+      "integrity": "sha512-8mpnvfcLcnVh+t1ok6V9eozWo8Ut+TZhz8ylJ6gF9d6q9EGDQX6s8jenan5Yv/pzN4vQEKI4ib2pTf/FELw+SA==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.2",
-        "chalk": "^4.0.0",
-        "debug": "^2.2.0",
+        "@react-native/dev-middleware": "0.81.4",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.82.0",
-        "metro-config": "^0.82.0",
-        "metro-core": "^0.82.0",
+        "metro": "^0.83.1",
+        "metro-config": "^0.83.1",
+        "metro-core": "^0.83.1",
         "semver": "^7.1.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@react-native-community/cli": "*"
+        "@react-native-community/cli": "*",
+        "@react-native/metro-config": "*"
       },
       "peerDependenciesMeta": {
         "@react-native-community/cli": {
           "optional": true
+        },
+        "@react-native/metro-config": {
+          "optional": true
         }
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.2.tgz",
-      "integrity": "sha512-cGmC7X6kju76DopSBNc+PRAEetbd7TWF9J9o84hOp/xL3ahxR2kuxJy0oJX8Eg8oehhGGEXTuMKHzNa3rDBeSg==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.2.tgz",
-      "integrity": "sha512-9q4CpkklsAs1L0Bw8XYCoqqyBSrfRALGEw4/r0EkR38Y/6fVfNfdsjSns0pTLO6h0VpxswK34L/hm4uK3MoLHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.2",
-        "chrome-launcher": "^0.15.2",
-        "chromium-edge-launcher": "^0.2.0",
-        "connect": "^3.6.5",
-        "debug": "^2.2.0",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "open": "^7.0.3",
-        "serve-static": "^1.16.2",
-        "ws": "^6.2.3"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
@@ -2928,26 +4073,26 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.4.tgz",
-      "integrity": "sha512-Gg4LhxHIK86Bi2RiT1rbFAB6fuwANRsaZJ1sFZ1OZEMQEx6stEnzaIrmfgzcv4z0bTQdQ8lzCrpsz0qtdaD4eA==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.2.tgz",
+      "integrity": "sha512-cGmC7X6kju76DopSBNc+PRAEetbd7TWF9J9o84hOp/xL3ahxR2kuxJy0oJX8Eg8oehhGGEXTuMKHzNa3rDBeSg==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.4.tgz",
-      "integrity": "sha512-OWRDNkgrFEo+OSC5QKfiiBmGXKoU8gmIABK8rj2PkgwisFQ/22p7MzE5b6oB2lxWaeJT7jBX5KVniNqO46VhHA==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.2.tgz",
+      "integrity": "sha512-9q4CpkklsAs1L0Bw8XYCoqqyBSrfRALGEw4/r0EkR38Y/6fVfNfdsjSns0pTLO6h0VpxswK34L/hm4uK3MoLHw==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.4",
+        "@react-native/debugger-frontend": "0.79.2",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
-        "debug": "^2.2.0",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
@@ -2955,23 +4100,8 @@
         "ws": "^6.2.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
       "version": "6.2.3",
@@ -2983,28 +4113,51 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.2.tgz",
-      "integrity": "sha512-6MJFemrwR0bOT0QM+2BxX9k3/pvZQNmJ3Js5pF/6owsA0cUDiCO57otiEU8Fz+UywWEzn1FoQfOfQ8vt2GYmoA==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.81.4.tgz",
+      "integrity": "sha512-T7fPcQvDDCSusZFVSg6H1oVDKb/NnVYLnsqkcHsAF2C2KGXyo3J7slH/tJAwNfj/7EOA2OgcWxfC1frgn9TQvw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.2.tgz",
-      "integrity": "sha512-IaY87Ckd4GTPMkO1/Fe8fC1IgIx3vc3q9Tyt/6qS3Mtk9nC0x9q4kSR5t+HHq0/MuvGtu8HpdxXGy5wLaM+zUw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.81.4.tgz",
+      "integrity": "sha512-sr42FaypKXJHMVHhgSbu2f/ZJfrLzgaoQ+HdpRvKEiEh2mhFf6XzZwecyLBvWqf2pMPZa+CpPfNPiejXjKEy8w==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.4.tgz",
-      "integrity": "sha512-247/8pHghbYY2wKjJpUsY6ZNbWcdUa5j5517LZMn6pXrbSSgWuj3JA4OYibNnocCHBaVrt+3R8XC3VEJqLlHFg==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.2.tgz",
+      "integrity": "sha512-+b+GNrupWrWw1okHnEENz63j7NSMqhKeFMOyzYLBwKcprG8fqJQhDIGXfizKdxeIa5NnGSAevKL1Ev1zJ56X8w==",
       "license": "MIT"
+    },
+    "node_modules/@react-native/virtualized-lists": {
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.2.tgz",
+      "integrity": "sha512-9G6ROJeP+rdw9Bvr5ruOlag11ET7j1z/En1riFFNo6W3xZvJY+alCuH1ttm12y9+zBm4n8jwCk4lGhjYaV4dKw==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@react-navigation/core": {
       "version": "7.12.1",
@@ -4551,27 +5704,31 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "53.0.15",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.15.tgz",
-      "integrity": "sha512-tOMnpM1iHHUKcG6QzpE8Pm+d56XIyaxiOkXyDHiHrDziBMAI+ngBlZZ3xU/vuyMFiJWBCx5KAqiKsliKTEQi6Q==",
+      "version": "54.0.0",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.0.tgz",
+      "integrity": "sha512-m3D2xF/uriHTxI+t8Lk8UFr7GZWv+dkmp/ajE1FhYaLMzsxq/IXVJ7gAS31TYmaxnYc82H1lQ02/CvnIZBXw7g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.24.16",
-        "@expo/config": "~11.0.11",
-        "@expo/config-plugins": "~10.0.3",
-        "@expo/fingerprint": "0.13.3",
-        "@expo/metro-config": "0.20.15",
-        "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~13.2.1",
-        "expo-asset": "~11.1.6",
-        "expo-constants": "~17.1.6",
-        "expo-file-system": "~18.1.11",
-        "expo-font": "~13.3.2",
-        "expo-keep-awake": "~14.1.4",
-        "expo-modules-autolinking": "2.1.13",
-        "expo-modules-core": "2.4.1",
-        "react-native-edge-to-edge": "1.6.0",
+        "@expo/cli": "54.0.0",
+        "@expo/config": "~12.0.7",
+        "@expo/config-plugins": "~54.0.0",
+        "@expo/devtools": "0.1.6",
+        "@expo/fingerprint": "0.15.0",
+        "@expo/metro": "~0.1.1",
+        "@expo/metro-config": "54.0.0",
+        "@expo/vector-icons": "^15.0.2",
+        "@ungap/structured-clone": "^1.3.0",
+        "babel-preset-expo": "~54.0.0",
+        "expo-asset": "~12.0.7",
+        "expo-constants": "~18.0.7",
+        "expo-file-system": "~19.0.11",
+        "expo-font": "~14.0.7",
+        "expo-keep-awake": "~15.0.6",
+        "expo-modules-autolinking": "3.0.9",
+        "expo-modules-core": "3.0.15",
+        "pretty-format": "^29.7.0",
+        "react-refresh": "^0.14.2",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
       "bin": {
@@ -4628,13 +5785,13 @@
       }
     },
     "node_modules/expo-dev-client": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-5.2.2.tgz",
-      "integrity": "sha512-shOMVwnfpq8ptpix+KveFz9UWv4SNxqxFYkEvRfsgyLiUG8O1vXE0FaZUNZgF+idOPGuO6C34YZM6pLzE0Dd6A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-5.2.0.tgz",
+      "integrity": "sha512-7GgO3BGlFM016Zkp3c9bUbi35pubqKh8Z/iHC1arIvckEjDrLER+92zfUTFr49XLk2o64arItRPJyQL49pA/hg==",
       "license": "MIT",
       "dependencies": {
-        "expo-dev-launcher": "5.1.14",
-        "expo-dev-menu": "6.1.12",
+        "expo-dev-launcher": "5.1.12",
+        "expo-dev-menu": "6.1.11",
         "expo-dev-menu-interface": "1.10.0",
         "expo-manifests": "~0.16.5",
         "expo-updates-interface": "~1.1.0"
@@ -4652,13 +5809,13 @@
       }
     },
     "node_modules/expo-dev-launcher": {
-      "version": "5.1.14",
-      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-5.1.14.tgz",
-      "integrity": "sha512-pxXqn8xCgOuc+W32mRJ9DiVK7O0zmGTG/ePd3kw53Xg1PKB9iOeYNty53qZEkIWjt8xdqS0JdECQT4qjgA2d1g==",
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-5.1.12.tgz",
+      "integrity": "sha512-ALedYerjJtSiPa95l41zMAO/m1m1kgS39i2H0io+6Ix4OksYNhILNzMNB1qDht/oWt2yjLBvXfWULfs5+3vnaA==",
       "license": "MIT",
       "dependencies": {
         "ajv": "8.11.0",
-        "expo-dev-menu": "6.1.12",
+        "expo-dev-menu": "6.1.11",
         "expo-manifests": "~0.16.5",
         "resolve-from": "^5.0.0"
       },
@@ -4689,30 +5846,30 @@
       "license": "MIT"
     },
     "node_modules/expo-dev-menu": {
-      "version": "6.1.12",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-6.1.12.tgz",
-      "integrity": "sha512-Bz8yjZ6a+u7ZrZWzfn3aCgBwAX+QB0ktQyV7QMS5/agyesKiqM43+VdwNQqrm8w9tS8HZ2sf6RTvdek8YgOEHg==",
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-6.1.11.tgz",
+      "integrity": "sha512-yrlDXGcqlbQX3Pgw/iPLRea7+pHFC17MdtkNaXYQ5K5u64mn9l4KZ2ZYUeQ8cKDG5l8ZdC4F9R9vfCJYFi82AA==",
       "license": "MIT",
       "dependencies": {
-        "expo-dev-menu-interface": "1.10.0"
+        "expo-dev-menu-interface": "2.0.0"
       },
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-dev-menu-interface": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.10.0.tgz",
-      "integrity": "sha512-NxtM/qot5Rh2cY333iOE87dDg1S8CibW+Wu4WdLua3UMjy81pXYzAGCZGNOeY7k9GpNFqDPNDXWyBSlk9r2pBg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
+      "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }
     },
     "node_modules/expo-eas-client": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.14.3.tgz",
-      "integrity": "sha512-BW2mSNEjFRFC8/CbkMQ3mfVhBdeZIjZhNfncw7PP80xEptLWhVjGTqwG8Usi0/yPpIu/YNYgop+XGMfhXyh9uA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.7.tgz",
+      "integrity": "sha512-Q/b1X0fM+3beqqvffok14pjxMF600NxopdSr9WJY61fF4xllcVnALS0kEudffp9ihMOfcb5xWYqzKj6jMqYDIw==",
       "license": "MIT"
     },
     "node_modules/expo-file-system": {
@@ -4755,12 +5912,12 @@
       }
     },
     "node_modules/expo-manifests": {
-      "version": "0.16.5",
-      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.16.5.tgz",
-      "integrity": "sha512-zLUeJogn2C7qOE75Zz7jcmJorMfIbSRR35ctspN0OK/Hq/+PAAptA8p9jNVC8xp/91uP9uI8f3xPhh+A11eR2A==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.8.tgz",
+      "integrity": "sha512-nA5PwU2uiUd+2nkDWf9e71AuFAtbrb330g/ecvuu52bmaXtN8J8oiilc9BDvAX0gg2fbtOaZdEdjBYopt1jdlQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~11.0.10",
+        "@expo/config": "~12.0.8",
         "expo-json-utils": "~0.15.0"
       },
       "peerDependencies": {
@@ -4768,9 +5925,9 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.13.tgz",
-      "integrity": "sha512-+SaiYkdP3LXOFm/26CHMHBof9Xq/0MHNDzL/K0OwPgHLhZ6wpDWIDYWRHNueWYtGpAeLw2XAhR0HX4FNtU09qw==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.9.tgz",
+      "integrity": "sha512-WyFGBcxWXo9lYZ2h1iBvE2GFPdgpjAfo45OKJLOIQhwckbeWv9849BcIVwGelEGEjoQ4jaugwo6UyaYIoCGHrw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -4852,13 +6009,12 @@
       }
     },
     "node_modules/expo-status-bar": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.2.3.tgz",
-      "integrity": "sha512-+c8R3AESBoduunxTJ8353SqKAKpxL6DvcD8VKBuh81zzJyUUbfB4CVjr1GufSJEKsMzNPXZU+HJwXx7Xh7lx8Q==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-3.0.8.tgz",
+      "integrity": "sha512-L248XKPhum7tvREoS1VfE0H6dPCaGtoUWzRsUv7hGKdiB4cus33Rc0sxkWkoQ77wE8stlnUlL5lvmT0oqZ3ZBw==",
       "license": "MIT",
       "dependencies": {
-        "react-native-edge-to-edge": "1.6.0",
-        "react-native-is-edge-to-edge": "^1.1.6"
+        "react-native-is-edge-to-edge": "^1.2.1"
       },
       "peerDependencies": {
         "react": "*",
@@ -4866,27 +6022,29 @@
       }
     },
     "node_modules/expo-structured-headers": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.1.0.tgz",
-      "integrity": "sha512-2X+aUNzC/qaw7/WyUhrVHNDB0uQ5rE12XA2H/rJXaAiYQSuOeU90ladaN0IJYV9I2XlhYrjXLktLXWbO7zgbag==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+      "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
       "license": "MIT"
     },
     "node_modules/expo-updates": {
-      "version": "0.28.15",
-      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.28.15.tgz",
-      "integrity": "sha512-JwmZ5RP7sPUgl+7FoP62Qs1gfkpYzJGhc6LfAiVSK9pxV0PWNP1jxzE9Jp4GSm/Ya9Tbz0mjDYaZPwoUGcUd+g==",
+      "version": "0.28.14",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.28.14.tgz",
+      "integrity": "sha512-kxI428W7LGSdDWmN/ud5cIg8+SjmQ5XSaUrYauZ0DKsHm2qq1Lh+NYSUWLvYmps+Baalafe6mILmAX8ZnNg26Q==",
       "license": "MIT",
       "dependencies": {
         "@expo/code-signing-certificates": "0.0.5",
         "@expo/config": "~11.0.10",
-        "@expo/config-plugins": "~10.0.3",
+        "@expo/config-plugins": "~10.0.2",
         "@expo/spawn-async": "^1.7.2",
         "arg": "4.1.0",
         "chalk": "^4.1.2",
-        "expo-eas-client": "~0.14.3",
-        "expo-manifests": "~0.16.5",
-        "expo-structured-headers": "~4.1.0",
-        "expo-updates-interface": "~1.1.0",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~1.0.7",
+        "expo-manifests": "~1.0.8",
+        "expo-structured-headers": "~5.0.0",
+        "expo-updates-interface": "~2.0.0",
+        "getenv": "^2.0.0",
         "glob": "^10.4.2",
         "ignore": "^5.3.1",
         "resolve-from": "^5.0.0"
@@ -4896,13 +6054,14 @@
       },
       "peerDependencies": {
         "expo": "*",
-        "react": "*"
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-updates-interface": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
-      "integrity": "sha512-DeB+fRe0hUDPZhpJ4X4bFMAItatFBUPjw/TVSbJsaf3Exeami+2qbbJhWkcTMoYHOB73nOIcaYcWXYJnCJXO0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
@@ -4914,18 +6073,84 @@
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
       "license": "MIT"
     },
-    "node_modules/expo-updates/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
+    "node_modules/expo/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/cli": {
+      "version": "54.0.0",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.0.tgz",
+      "integrity": "sha512-pt+GYt9gXNWmEri5SpIUXHJjD7vZBV6WJFCg7Lie1e62ELcp3aquC6YCCpWfb+89ruDVv2uWWmg6sQXMI9BhLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.8",
+        "@expo/code-signing-certificates": "^0.0.5",
+        "@expo/config": "~12.0.7",
+        "@expo/config-plugins": "~54.0.0",
+        "@expo/devcert": "^1.1.2",
+        "@expo/env": "~2.0.6",
+        "@expo/image-utils": "^0.8.6",
+        "@expo/json-file": "^10.0.6",
+        "@expo/metro": "~0.1.1",
+        "@expo/metro-config": "~54.0.0",
+        "@expo/osascript": "^2.3.6",
+        "@expo/package-manager": "^1.9.6",
+        "@expo/plist": "^0.4.6",
+        "@expo/prebuild-config": "^54.0.0",
+        "@expo/schema-utils": "^0.1.6",
+        "@expo/server": "^0.7.3",
+        "@expo/spawn-async": "^1.7.2",
+        "@expo/ws-tunnel": "^1.0.1",
+        "@expo/xcpretty": "^4.3.0",
+        "@react-native/dev-middleware": "0.81.4",
+        "@urql/core": "^5.0.6",
+        "@urql/exchange-retry": "^1.3.0",
+        "accepts": "^1.3.8",
+        "arg": "^5.0.2",
+        "better-opn": "~3.0.2",
+        "bplist-creator": "0.1.0",
+        "bplist-parser": "^0.3.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.3.0",
+        "compression": "^1.7.4",
+        "connect": "^3.7.0",
+        "debug": "^4.3.4",
+        "env-editor": "^0.4.1",
+        "freeport-async": "^2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "lan-network": "^0.1.6",
+        "minimatch": "^9.0.0",
+        "node-forge": "^1.3.1",
+        "npm-package-arg": "^11.0.0",
+        "ora": "^3.4.0",
+        "picomatch": "^3.0.1",
+        "pretty-bytes": "^5.6.0",
+        "pretty-format": "^29.7.0",
+        "progress": "^2.0.3",
+        "prompts": "^2.3.2",
+        "qrcode-terminal": "0.11.0",
+        "require-from-string": "^2.0.2",
+        "requireg": "^0.2.2",
+        "resolve": "^1.22.2",
+        "resolve-from": "^5.0.0",
+        "resolve.exports": "^2.0.3",
+        "semver": "^7.6.0",
+        "send": "^0.19.0",
+        "slugify": "^1.3.4",
+        "source-map-support": "~0.5.21",
+        "stacktrace-parser": "^0.1.10",
+        "structured-headers": "^0.4.1",
+        "tar": "^7.4.3",
+        "terminal-link": "^2.1.1",
+        "undici": "^6.18.2",
+        "wrap-ansi": "^7.0.0",
+        "ws": "^8.12.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
@@ -4934,41 +6159,156 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/expo-updates/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
+    "node_modules/expo/node_modules/@expo/config": {
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.8.tgz",
+      "integrity": "sha512-yFadXa5Cmja57EVOSyEYV1hF7kCaSbPnd1twx0MfvTr1Yj2abIbrEu2MUZqcvElNQOtgADnLRP0YJiuEdgoO5A==",
+      "license": "MIT",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~54.0.0",
+        "@expo/config-types": "^54.0.7",
+        "@expo/json-file": "^10.0.7",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.35.0"
       }
     },
-    "node_modules/expo-updates/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
-    "node_modules/expo-updates/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
+    "node_modules/expo/node_modules/@expo/config-plugins": {
+      "version": "54.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.1.tgz",
+      "integrity": "sha512-NyBChhiWFL6VqSgU+LzK4R1vC397tEG2XFewVt4oMr4Pnalq/mJxBANQrR+dyV1RHhSyhy06RNiJIkQyngVWeg==",
+      "license": "MIT",
       "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "~10.0.7",
+        "@expo/plist": "^0.4.7",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/config-types": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
+      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
+      "license": "MIT"
+    },
+    "node_modules/expo/node_modules/@expo/json-file": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
+      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo/node_modules/@expo/plist": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/debugger-frontend": {
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.81.4.tgz",
+      "integrity": "sha512-SU05w1wD0nKdQFcuNC9D6De0ITnINCi8MEnx9RsTD2e4wN83ukoC7FpXaPCYyP6+VjFt5tUKDPgP1O7iaNXCqg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/dev-middleware": {
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.81.4.tgz",
+      "integrity": "sha512-hu1Wu5R28FT7nHXs2wWXvQ++7W7zq5GPY83llajgPlYKznyPLAY/7bArc5rAzNB7b0kwnlaoPQKlvD/VP9LZug==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.81.4",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^6.2.3"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.18"
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/expo/node_modules/@react-native/dev-middleware/node_modules/ws": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "node_modules/expo/node_modules/getenv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+      "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expo/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/exponential-backoff": {
@@ -5096,6 +6436,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.0.0.tgz",
+      "integrity": "sha512-KV+OrMJpi2uXlqL2zaCcXb7YuQbY/gMIWT1hf8hKeTW1bSumWaHT5qfmn0WTpHwKQa3QEVOtZR2ta9EchcmYuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.0.0",
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-compat": "0.2.24",
+        "@firebase/app": "0.14.0",
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-compat": "0.4.0",
+        "@firebase/app-compat": "0.5.0",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-compat": "0.6.0",
+        "@firebase/data-connect": "0.3.11",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-compat": "2.1.0",
+        "@firebase/firestore": "4.9.0",
+        "@firebase/firestore-compat": "0.4.0",
+        "@firebase/functions": "0.13.0",
+        "@firebase/functions-compat": "0.4.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-compat": "0.2.19",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/messaging-compat": "0.2.23",
+        "@firebase/performance": "0.7.8",
+        "@firebase/performance-compat": "0.2.21",
+        "@firebase/remote-config": "0.6.6",
+        "@firebase/remote-config-compat": "0.2.19",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-compat": "0.4.0",
+        "@firebase/util": "1.13.0"
       }
     },
     "node_modules/flow-enums-runtime": {
@@ -6299,9 +7675,9 @@
       "license": "MIT"
     },
     "node_modules/metro": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.4.tgz",
-      "integrity": "sha512-/gFmw3ux9CPG5WUmygY35hpyno28zi/7OUn6+OFfbweA8l0B+PPqXXLr0/T6cf5nclCcH0d22o+02fICaShVxw==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.3.tgz",
+      "integrity": "sha512-EfSLtuUmfsGk3znJ+zoN8cRLniQo3W1wyA+nJMfpTLdENfbbPnGRTwmKhzRcJIUh9jgkrrF4oRQ5shLtQ2DsUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -6319,24 +7695,24 @@
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.28.1",
+        "hermes-parser": "0.29.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-cache-key": "0.82.4",
-        "metro-config": "0.82.4",
-        "metro-core": "0.82.4",
-        "metro-file-map": "0.82.4",
-        "metro-resolver": "0.82.4",
-        "metro-runtime": "0.82.4",
-        "metro-source-map": "0.82.4",
-        "metro-symbolicate": "0.82.4",
-        "metro-transform-plugins": "0.82.4",
-        "metro-transform-worker": "0.82.4",
+        "metro-babel-transformer": "0.82.3",
+        "metro-cache": "0.82.3",
+        "metro-cache-key": "0.82.3",
+        "metro-config": "0.82.3",
+        "metro-core": "0.82.3",
+        "metro-file-map": "0.82.3",
+        "metro-resolver": "0.82.3",
+        "metro-runtime": "0.82.3",
+        "metro-source-map": "0.82.3",
+        "metro-symbolicate": "0.82.3",
+        "metro-transform-plugins": "0.82.3",
+        "metro-transform-worker": "0.82.3",
         "mime-types": "^2.1.27",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -6349,103 +7725,103 @@
         "metro": "src/cli.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.4.tgz",
-      "integrity": "sha512-4juJahGRb1gmNbQq48lNinB6WFNfb6m0BQqi/RQibEltNiqTCxew/dBspI2EWA4xVCd3mQWGfw0TML4KurQZnQ==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.3.tgz",
+      "integrity": "sha512-eC0f1MSA8rg7VoNDCYMIAIe5AEgYBskh5W8rIa4RGRdmEOsGlXbAV0AWMYoA7NlIALW/S9b10AcdIwD3n1e50w==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.28.1",
+        "hermes-parser": "0.29.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
       "license": "MIT"
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.28.1"
+        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.4.tgz",
-      "integrity": "sha512-vX0ylSMGtORKiZ4G8uP6fgfPdDiCWvLZUGZ5zIblSGylOX6JYhvExl0Zg4UA9pix/SSQu5Pnp9vdODMFsNIxhw==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.3.tgz",
+      "integrity": "sha512-9zKhicA5GENROeP+iXku1NrI8FegtwEg3iPXHGixkm1Yppkbwsy/3lSHSiJZoT6GkZmxUDjN6sQ5QQ+/p72Msw==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.82.4"
+        "metro-core": "0.82.3"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.4.tgz",
-      "integrity": "sha512-2JCTqcpF+f2OghOpe/+x+JywfzDkrHdAqinPFWmK2ezNAU/qX0jBFaTETogPibFivxZJil37w9Yp6syX8rFUng==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.3.tgz",
+      "integrity": "sha512-dDLTUOJ7YYqGog9kR55InchwnkkHuxBXD765J3hQVWWPCy6xO9uZXZYGX1Y/tIMV8U7Ho1Sve0V13n5rFajrRQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-config": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.4.tgz",
-      "integrity": "sha512-Ki3Wumr3hKHGDS7RrHsygmmRNc/PCJrvkLn0+BWWxmbOmOcMMJDSmSI+WRlT8jd5VPZFxIi4wg+sAt5yBXAK0g==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.3.tgz",
+      "integrity": "sha512-GRG9sBkPvrGXD/Wu3RdEDuWg5NDixF9t0c6Zz9kZ9Aa/aQY+m85JgaCI5HYEV+UzVC/IUFFSpJiMfzQRicppLw==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-core": "0.82.4",
-        "metro-runtime": "0.82.4"
+        "metro": "0.82.3",
+        "metro-cache": "0.82.3",
+        "metro-core": "0.82.3",
+        "metro-runtime": "0.82.3"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.4.tgz",
-      "integrity": "sha512-Xo4ozbxPg2vfgJGCgXZ8sVhC2M0lhTqD+tsKO2q9aelq/dCjnnSb26xZKcQO80CQOQUL7e3QWB7pLFGPjZm31A==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.3.tgz",
+      "integrity": "sha512-JQZDdXo3hyLl1pqVT4IKEwcBK+3f11qFXeCjQ1hjVpjMwQLOqSM02J7NC/4DNSBt+qWBxWj6R5Jphcc7+9AEWw==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.82.4"
+        "metro-resolver": "0.82.3"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.4.tgz",
-      "integrity": "sha512-eO7HD1O3aeNsbEe6NBZvx1lLJUrxgyATjnDmb7bm4eyF6yWOQot9XVtxTDLNifECuvsZ4jzRiTInrbmIHkTdGA==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.3.tgz",
+      "integrity": "sha512-o4wtloAge85MZl85F87FT59R/4tn5GvCvLfYcnzzDB20o2YX9AMxZqswrGMaei/GbD/Win5FrLF/Iq8oetcByA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -6459,51 +7835,51 @@
         "walker": "^1.0.7"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.4.tgz",
-      "integrity": "sha512-W79Mi6BUwWVaM8Mc5XepcqkG+TSsCyyo//dmTsgYfJcsmReQorRFodil3bbJInETvjzdnS1mCsUo9pllNjT1Hg==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.3.tgz",
+      "integrity": "sha512-/3FasOULfHq1P0KPNFy5y28Th5oknPSwEbt9JELVBMAPhUnLqQkCLr4M+RQzKG3aEQN1/mEqenWApFCkk6Nm/Q==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.4.tgz",
-      "integrity": "sha512-uWoHzOBGQTPT5PjippB8rRT3iI9CTgFA9tRiLMzrseA5o7YAlgvfTdY9vFk2qyk3lW3aQfFKWkmqENryPRpu+Q==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.3.tgz",
+      "integrity": "sha512-pdib7UrOM04j/RjWmaqmjjWRiuCbpA8BdUSuXzvBaK0QlNzHkRRDv6kiOGxgQ+UgG+KdbPcJktsW9olqiDhf9w==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.4.tgz",
-      "integrity": "sha512-vVyFO7H+eLXRV2E7YAUYA7aMGBECGagqxmFvC2hmErS7oq90BbPVENfAHbUWq1vWH+MRiivoRxdxlN8gBoF/dw==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.3.tgz",
+      "integrity": "sha512-J4SrUUsBy9ire8I2sFuXN5MzPmuBHlx1bjvAjdoo1ecpH2mtS3ubRqVnMotBxuK5+GhrbW0mtg5/46PVXy26cw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.4.tgz",
-      "integrity": "sha512-9jzDQJ0FPas1FuQFtwmBHsez2BfhFNufMowbOMeG3ZaFvzeziE8A0aJwILDS3U+V5039ssCQFiQeqDgENWvquA==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.3.tgz",
+      "integrity": "sha512-gz7wfjz23rit6ePQ7NKE9x+VOWGKm54vli4wbphR9W+3y0bh6Ad7T0BGH9DUzRAnOnOorewrVEqFmT24mia5sg==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -6511,25 +7887,25 @@
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.82.4",
+        "metro-symbolicate": "0.82.3",
         "nullthrows": "^1.1.1",
-        "ob1": "0.82.4",
+        "ob1": "0.82.3",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.4.tgz",
-      "integrity": "sha512-LwEwAtdsx7z8rYjxjpLWxuFa2U0J6TS6ljlQM4WAATKa4uzV8unmnRuN2iNBWTmRqgNR77mzmI2vhwD4QSCo+w==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.3.tgz",
+      "integrity": "sha512-WZKhR+QGbwkOLWP1z58Y7BFWUqLVDEEPsSQ5UI5+OWQDAwdtsPU9+sSNoJtD5qRU9qrB2XewQE3lJ2EQRRFJew==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.82.4",
+        "metro-source-map": "0.82.3",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -6538,13 +7914,13 @@
         "metro-symbolicate": "src/index.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.4.tgz",
-      "integrity": "sha512-NoWQRPHupVpnDgYguiEcm7YwDhnqW02iWWQjO2O8NsNP09rEMSq99nPjARWfukN7+KDh6YjLvTIN20mj3dk9kw==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.3.tgz",
+      "integrity": "sha512-s1gVrkhczwMbxZLRSLCJ16K/4Sqx5IhO4sWlL6j0jlIEs1/Drn3JrkUUdQTtgmJS8SBpxmmB66cw7wnz751dVg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -6555,13 +7931,13 @@
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.4.tgz",
-      "integrity": "sha512-kPI7Ad/tdAnI9PY4T+2H0cdgGeSWWdiPRKuytI806UcN4VhFL6OmYa19/4abYVYF+Cd2jo57CDuwbaxRfmXDhw==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.3.tgz",
+      "integrity": "sha512-z5Y7nYlSlLAEhjFi73uEJh69G5IC6HFZmXFcrxnY+JNlsjT2r0GgsDF4WaQGtarAIt5NP88V8983/PedwNfEcw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -6569,17 +7945,17 @@
         "@babel/parser": "^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.82.4",
-        "metro-babel-transformer": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-cache-key": "0.82.4",
-        "metro-minify-terser": "0.82.4",
-        "metro-source-map": "0.82.4",
-        "metro-transform-plugins": "0.82.4",
+        "metro": "0.82.3",
+        "metro-babel-transformer": "0.82.3",
+        "metro-cache": "0.82.3",
+        "metro-cache-key": "0.82.3",
+        "metro-minify-terser": "0.82.3",
+        "metro-source-map": "0.82.3",
+        "metro-transform-plugins": "0.82.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro/node_modules/ci-info": {
@@ -6589,18 +7965,18 @@
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.28.1"
+        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/metro/node_modules/ws": {
@@ -6891,15 +8267,15 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.4.tgz",
-      "integrity": "sha512-n9S8e4l5TvkrequEAMDidl4yXesruWTNTzVkeaHSGywoTOIwTzZzKw7Z670H3eaXDZui5MJXjWGNzYowVZIxCA==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.3.tgz",
+      "integrity": "sha512-8/SeymYlPMVODpCATHqm+X8eiuvD1GsKVa11n688V4GGgjrM3CRvrbtrYBs4t89LJDkv5CwGYPdqayuY0DmTTA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/object-assign": {
@@ -7452,18 +8828,18 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.3.tgz",
-      "integrity": "sha512-4be9IVco12d/4D7NpZgNjffbYIo/MAk4f5eBJR8PpKyiR7tgwe29liQbxyqDov5Ybc2crGABZyYAmdeU6NowKg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.2.tgz",
+      "integrity": "sha512-ldFwzufLletzCikNJVYaxlxMLu7swJ3T2VrGfzXlMsVhZhPDKXA38DEROidaYZVgMAmQnIjymrmqto5pyfrwPA==",
       "license": "MIT",
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -7492,15 +8868,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.26.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.1.0"
       }
     },
     "node_modules/react-freeze": {
@@ -7522,42 +8898,40 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.2.tgz",
-      "integrity": "sha512-AnGzb56JvU5YCL7cAwg10+ewDquzvmgrMddiBM0GAWLwQM/6DJfGd2ZKrMuKKehHerpDDZgG+EY64gk3x3dEkw==",
+      "version": "0.81.4",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.4.tgz",
+      "integrity": "sha512-bt5bz3A/+Cv46KcjV0VQa+fo7MKxs17RCcpzjftINlen4ZDUl0I6Ut+brQ2FToa5oD0IB0xvQHfmsg2EDqsZdQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.2",
-        "@react-native/codegen": "0.79.2",
-        "@react-native/community-cli-plugin": "0.79.2",
-        "@react-native/gradle-plugin": "0.79.2",
-        "@react-native/js-polyfills": "0.79.2",
-        "@react-native/normalize-colors": "0.79.2",
-        "@react-native/virtualized-lists": "0.79.2",
+        "@react-native/assets-registry": "0.81.4",
+        "@react-native/codegen": "0.81.4",
+        "@react-native/community-cli-plugin": "0.81.4",
+        "@react-native/gradle-plugin": "0.81.4",
+        "@react-native/js-polyfills": "0.81.4",
+        "@react-native/normalize-colors": "0.81.4",
+        "@react-native/virtualized-lists": "0.81.4",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "0.25.1",
+        "babel-plugin-syntax-hermes-parser": "0.29.1",
         "base64-js": "^1.5.1",
-        "chalk": "^4.0.0",
         "commander": "^12.0.0",
-        "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
         "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.7.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.82.0",
-        "metro-source-map": "^0.82.0",
+        "metro-runtime": "^0.83.1",
+        "metro-source-map": "^0.83.1",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
-        "react-devtools-core": "^6.1.1",
+        "react-devtools-core": "^6.1.5",
         "react-refresh": "^0.14.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.25.0",
+        "scheduler": "0.26.0",
         "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
@@ -7568,11 +8942,11 @@
         "react-native": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "^19.0.0"
+        "@types/react": "^19.1.0",
+        "react": "^19.1.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -7580,20 +8954,10 @@
         }
       }
     },
-    "node_modules/react-native-edge-to-edge": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
-      "integrity": "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-gesture-handler": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.24.0.tgz",
-      "integrity": "sha512-ZdWyOd1C8axKJHIfYxjJKCcxjWEpUtUWgTOVY2wynbiveSQDm8X/PDyAKXSer/GOtIpjudUbACOndZXCN3vHsw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
@@ -7606,9 +8970,9 @@
       }
     },
     "node_modules/react-native-is-edge-to-edge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
-      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
+      "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -7616,34 +8980,37 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.0.tgz",
+      "integrity": "sha512-L8FqZn8VjZyBaCUMYFyx1Y+T+ZTbblaudpxReOXJ66RnOf52g6UM4Pa/IjwLD1XAw1FUxLRQrtpdjbkEc74FiQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4",
-        "react-native-is-edge-to-edge": "1.1.7"
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "7.7.2"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "react-native-worklets": ">=0.5.0"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
-      "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
+      "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -7651,12 +9018,13 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.10.0.tgz",
-      "integrity": "sha512-Tw21NGuXm3PbiUGtZd0AnXirUixaAbPXDjNR0baBH7/WJDaDTTELLcQ7QRXuqAWbmr/EVCrKj1348ei1KFIr8A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
+      "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",
+        "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {
@@ -7665,9 +9033,9 @@
       }
     },
     "node_modules/react-native-web": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz",
-      "integrity": "sha512-OOSgrw+aON6R3hRosCau/xVxdLzbjEcsLysYedka0ZON4ZZe6n9xgeN9ZkoejhARM36oTlUgHIQqxGutEJ9Wxg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.1.tgz",
+      "integrity": "sha512-BeNsgwwe4AXUFPAoFU+DKjJ+CVQa3h54zYX77p7GVZrXiiNo3vl03WYDYVEy5R2J2HOPInXtQZB5gmj3vuzrKg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
@@ -7695,54 +9063,6 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
-    },
-    "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.2.tgz",
-      "integrity": "sha512-8JTlGLuLi1p8Jx2N/enwwEd7/2CfrqJpv90Cp77QLRX3VHF2hdyavRIxAmXMwN95k+Me7CUuPtqn2X3IBXOWYg==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.1",
-        "hermes-parser": "0.25.1",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "yargs": "^17.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.2.tgz",
-      "integrity": "sha512-+b+GNrupWrWw1okHnEENz63j7NSMqhKeFMOyzYLBwKcprG8fqJQhDIGXfizKdxeIa5NnGSAevKL1Ev1zJ56X8w==",
-      "license": "MIT"
-    },
-    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.2",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.2.tgz",
-      "integrity": "sha512-9G6ROJeP+rdw9Bvr5ruOlag11ET7j1z/En1riFFNo6W3xZvJY+alCuH1ttm12y9+zBm4n8jwCk4lGhjYaV4dKw==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
     },
     "node_modules/react-native/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -7782,6 +9102,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/react-native/node_modules/hermes-estree": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.29.1.tgz",
+      "integrity": "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-native/node_modules/hermes-parser": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.29.1.tgz",
+      "integrity": "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.29.1"
       }
     },
     "node_modules/react-native/node_modules/minimatch": {
@@ -8046,9 +9381,9 @@
       "license": "ISC"
     },
     "node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -8771,13 +10106,13 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -9065,15 +10400,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/use-latest-callback": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/native-stack": "^7.3.13",
         "expo": "~53.0.9",
         "expo-dev-client": "~5.2.0",
+        "expo-mail-composer": "~15.0.1",
         "expo-status-bar": "~2.2.3",
         "expo-updates": "~0.28.14",
         "glob": "^11.0.3",
@@ -4638,6 +4639,14 @@
         "expo-manifests": "~0.16.5",
         "expo-updates-interface": "~1.1.0"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-mail-composer": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/expo-mail-composer/-/expo-mail-composer-15.0.1.tgz",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@react-navigation/native-stack": "^7.3.13",
     "expo": "~53.0.9",
     "expo-dev-client": "~5.2.0",
+    "expo-mail-composer": "~15.0.1",
     "expo-status-bar": "~2.2.3",
     "expo-updates": "~0.28.14",
     "glob": "^11.0.3",

--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
+    "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-navigation/native": "^7.1.9",
     "@react-navigation/native-stack": "^7.3.13",
-    "expo": "~53.0.9",
+    "expo": "54.0.0",
     "expo-dev-client": "~5.2.0",
-    "expo-mail-composer": "~15.0.1",
     "expo-status-bar": "~2.2.3",
     "expo-updates": "~0.28.14",
-    "glob": "^11.0.3",
+    "firebase": "^12.0.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.2",
@@ -29,8 +29,9 @@
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
+    "react-native-toast-message": "^2.3.3",
     "react-native-web": "^0.20.0",
-    "rimraf": "^6.0.1"
+    "expo-modules-core": "~3.0.15"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/screens/Advies10Hoog.js
+++ b/screens/Advies10Hoog.js
@@ -1,7 +1,34 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies10Hoog({ navigation }) {
+const adviceImage = require('../assets/10-KWH-ADVIES.jpg');
+
+export default function Advies10Hoog({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary:
+            'Je hebt een 3-fase aansluiting. Op basis van je gegevens adviseren wij:',
+          capacity: route?.params?.adviesCapacity ?? '10 kWh batterijopslag (Hoog Voltage)',
+          connection: route?.params?.aansluiting ?? '3-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-10H' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -9,10 +36,12 @@ export default function Advies10Hoog({ navigation }) {
       <Text style={styles.advice}>10 kWh batterijopslag (Hoog Voltage)</Text>
 
       <Image
-        source={require('../assets/10-KWH-ADVIES.jpg')}
+        source={adviceImage}
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -63,6 +92,9 @@ container: {
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });
 

--- a/screens/Advies10Laag.js
+++ b/screens/Advies10Laag.js
@@ -1,7 +1,34 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies10Laag({ navigation }) {
+const adviceImage = require('../assets/10-KWH-ADVIES-LAAG.jpg');
+
+export default function Advies10Laag({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary:
+            'Je hebt een 1-fase aansluiting. Op basis van je gegevens adviseren wij:',
+          capacity: route?.params?.adviesCapacity ?? '10 kWh batterijopslag (Laag Voltage)',
+          connection: route?.params?.aansluiting ?? '1-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-10L' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -11,10 +38,12 @@ export default function Advies10Laag({ navigation }) {
       <Text style={styles.advice}>10 kWh batterijopslag (Laag Voltage)</Text>
 
       <Image
-        source={require('../assets/10-KWH-ADVIES-LAAG.jpg')}
+        source={adviceImage}
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -65,5 +94,8 @@ const styles = StyleSheet.create({
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/Advies12_5Hoog.js
+++ b/screens/Advies12_5Hoog.js
@@ -1,7 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies12_5Hoog({ navigation }) {
+const adviceImage = require('../assets/12.5-KWH-ADVIES.jpg');
+
+export default function Advies12_5Hoog({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary: 'Je hebt een 3-fase aansluiting. Op basis van je gegevens adviseren wij:',
+          capacity: route?.params?.adviesCapacity ?? '12,5 kWh batterijopslag (Hoog Voltage)',
+          connection: route?.params?.aansluiting ?? '3-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-12P5' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -9,10 +35,12 @@ export default function Advies12_5Hoog({ navigation }) {
       <Text style={styles.advice}>12,5 kWh batterijopslag (Hoog Voltage)</Text>
 
       <Image
-        source={require('../assets/12.5-KWH-ADVIES.jpg')}
+        source={adviceImage}
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -63,5 +91,8 @@ container: {
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/Advies15Hoog.js
+++ b/screens/Advies15Hoog.js
@@ -1,7 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies15Hoog({ navigation }) {
+const adviceImage = require('../assets/15-KWH-ADVIES.jpg');
+
+export default function Advies15Hoog({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary: 'Je hebt een 3-fase aansluiting. Op basis van je gegevens adviseren wij:',
+          capacity: route?.params?.adviesCapacity ?? '15 kWh batterijopslag (Hoog Voltage)',
+          connection: route?.params?.aansluiting ?? '3-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-15H' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -9,10 +35,12 @@ export default function Advies15Hoog({ navigation }) {
       <Text style={styles.advice}>15 kWh batterijopslag (Hoog Voltage)</Text>
 
       <Image
-        source={require('../assets/15-KWH-ADVIES.jpg')}
+        source={adviceImage}
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -63,5 +91,8 @@ container: {
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/Advies17_5Hoog.js
+++ b/screens/Advies17_5Hoog.js
@@ -1,7 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies17_5Hoog({ navigation }) {
+const adviceImage = require('../assets/17.5-KWH-ADVIES.jpg');
+
+export default function Advies17_5Hoog({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary: 'Je hebt een 3-fase aansluiting. Op basis van je gegevens adviseren wij:',
+          capacity: route?.params?.adviesCapacity ?? '17,5 kWh batterijopslag (Hoog Voltage)',
+          connection: route?.params?.aansluiting ?? '3-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-17P5' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -9,10 +35,12 @@ export default function Advies17_5Hoog({ navigation }) {
       <Text style={styles.advice}>17,5 kWh batterijopslag (Hoog Voltage)</Text>
 
       <Image
-        source={require('../assets/17.5-KWH-ADVIES.jpg')}
+        source={adviceImage}
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -63,5 +91,8 @@ container: {
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/Advies20Hoog.js
+++ b/screens/Advies20Hoog.js
@@ -1,7 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies20Hoog({ navigation }) {
+const adviceImage = require('../assets/20-KWH-ADVIES.jpg');
+
+export default function Advies20Hoog({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary: 'Je hebt een 3-fase aansluiting. Op basis van je gegevens adviseren wij:',
+          capacity: route?.params?.adviesCapacity ?? '20 kWh batterijopslag (Hoog Voltage)',
+          connection: route?.params?.aansluiting ?? '3-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-20H' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -9,10 +35,12 @@ export default function Advies20Hoog({ navigation }) {
       <Text style={styles.advice}>20 kWh batterijopslag (Hoog Voltage)</Text>
 
       <Image
-        source={require('../assets/20-KWH-ADVIES.jpg')}
+        source={adviceImage}
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -63,5 +91,8 @@ container: {
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/Advies5kWhScreen.js
+++ b/screens/Advies5kWhScreen.js
@@ -1,7 +1,33 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies5kWhScreen({ navigation }) {
+const adviceImage = require('../assets/5-KWH-ADVIES.jpg');
+
+export default function Advies5kWhScreen({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary: 'Je hebt gekozen voor een 1-fase aansluiting met een 16A zekering.',
+          capacity: route?.params?.adviesCapacity ?? '5 kWh batterijopslag',
+          connection: route?.params?.aansluiting ?? '1-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-5' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -11,10 +37,12 @@ export default function Advies5kWhScreen({ navigation }) {
       </Text>
 
       <Image
-        source={require('../assets/5-KWH-ADVIES.jpg')} // vervang door .webp als dat nodig is
+        source={adviceImage} // vervang door .webp als dat nodig is
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('5 kWh Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -66,5 +94,8 @@ const styles = StyleSheet.create({
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/Advies7_5Hoog.js
+++ b/screens/Advies7_5Hoog.js
@@ -1,7 +1,34 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
-export default function Advies7_5Hoog({ navigation }) {
+const adviceImage = require('../assets/7.5-KWH-ADVIES.jpg');
+
+export default function Advies7_5Hoog({ navigation, route }) {
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Particulier' },
+        advice: {
+          title: 'Persoonlijk Advies',
+          summary:
+            'Je hebt een 3-fase aansluiting. Op basis van je gegevens adviseren wij:',
+          capacity: route?.params?.adviesCapacity ?? '7,5 kWh batterijopslag (Hoog Voltage)',
+          connection: route?.params?.aansluiting ?? '3-fase',
+          image: adviceImage,
+          inputs: {
+            verbruik: route?.params?.verbruik,
+            vermogenWp: route?.params?.vermogenWp,
+            aantalPanelen: route?.params?.aantalPanelen,
+          },
+        },
+        reference: { prefix: 'ADV-7P5' },
+      }),
+    [route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Persoonlijk Advies</Text>
@@ -11,10 +38,12 @@ export default function Advies7_5Hoog({ navigation }) {
       <Text style={styles.advice}>7,5 kWh batterijopslag (Hoog Voltage)</Text>
 
       <Image
-        source={require('../assets/7.5-KWH-ADVIES.jpg')}
+        source={adviceImage}
         style={styles.image}
         resizeMode="contain"
       />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.specButton} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.specButtonText}>Bekijk specificaties</Text>
@@ -65,5 +94,8 @@ const styles = StyleSheet.create({
   specButtonText: {
     color: '#fff',
     fontSize: 16
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/AdviesScreen.js
+++ b/screens/AdviesScreen.js
@@ -5,7 +5,12 @@ import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
 export default function AdviesScreen() {
   const route = useRoute();
   const navigation = useNavigation();
-  const { verbruik, vermogenWp, aantalPanelen, aansluiting } = route.params;
+  const verbruik = route.params?.verbruik ?? '—';
+  const vermogenWp = route.params?.vermogenWp ?? '—';
+  const aantalPanelen = route.params?.aantalPanelen ?? '—';
+  const aansluiting = route.params?.aansluiting ?? '—';
+  const clientType = route.params?.clientType ?? 'Particulier';
+  const zekering = route.params?.zekering ?? '—';
 
 useEffect(() => {
   const berekenAdvies = () => {
@@ -17,11 +22,26 @@ useEffect(() => {
 
     const gemiddeld = (kWh1 + kWh2) / 2;
 
+    const baseParams = {
+      clientType,
+      aansluiting,
+      verbruik,
+      vermogenWp,
+      aantalPanelen,
+      zekering,
+    };
+
     if (aansluiting === '1-fase') {
       if (gemiddeld <= 5) {
-        navigation.replace('Advies 5 kWh');
+        navigation.replace('Advies 5 kWh', {
+          ...baseParams,
+          adviesCapacity: '5 kWh batterijopslag',
+        });
       } else {
-        navigation.replace('Advies 10 kWh Laag');
+        navigation.replace('Advies 10 kWh Laag', {
+          ...baseParams,
+          adviesCapacity: '10 kWh batterijopslag (Laag Voltage)',
+        });
       }
     } else if (aansluiting === '3-fase') {
       const opties = [7.5, 10, 12.5, 15, 17.5, 20];
@@ -29,25 +49,46 @@ useEffect(() => {
 
       switch (gekozen) {
         case 7.5:
-          navigation.replace('Advies 7.5 kWh Hoog');
+          navigation.replace('Advies 7.5 kWh Hoog', {
+            ...baseParams,
+            adviesCapacity: '7.5 kWh batterijopslag (Hoog Voltage)',
+          });
           break;
         case 10:
-          navigation.replace('Advies 10 kWh Hoog');
+          navigation.replace('Advies 10 kWh Hoog', {
+            ...baseParams,
+            adviesCapacity: '10 kWh batterijopslag (Hoog Voltage)',
+          });
           break;
         case 12.5:
-          navigation.replace('Advies 12.5 kWh Hoog');
+          navigation.replace('Advies 12.5 kWh Hoog', {
+            ...baseParams,
+            adviesCapacity: '12.5 kWh batterijopslag (Hoog Voltage)',
+          });
           break;
         case 15:
-          navigation.replace('Advies 15 kWh Hoog');
+          navigation.replace('Advies 15 kWh Hoog', {
+            ...baseParams,
+            adviesCapacity: '15 kWh batterijopslag (Hoog Voltage)',
+          });
           break;
         case 17.5:
-          navigation.replace('Advies 17.5 kWh Hoog');
+          navigation.replace('Advies 17.5 kWh Hoog', {
+            ...baseParams,
+            adviesCapacity: '17.5 kWh batterijopslag (Hoog Voltage)',
+          });
           break;
         case 20:
-          navigation.replace('Advies 20 kWh Hoog');
+          navigation.replace('Advies 20 kWh Hoog', {
+            ...baseParams,
+            adviesCapacity: '20 kWh batterijopslag (Hoog Voltage)',
+          });
           break;
         default:
-          navigation.replace('Advies 20 kWh Hoog');
+          navigation.replace('Advies 20 kWh Hoog', {
+            ...baseParams,
+            adviesCapacity: '20 kWh batterijopslag (Hoog Voltage)',
+          });
       }
     }
   };

--- a/screens/Fase1Screen.js
+++ b/screens/Fase1Screen.js
@@ -5,22 +5,39 @@ import { useRoute } from '@react-navigation/native';
 export default function Fase1Screen({ navigation }) {
   const route = useRoute();
   const aansluiting = route.params?.aansluiting || '1-fase'; // fallback voor zekerheid
+  const clientType = route.params?.clientType || 'Particulier';
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Welke zekering heeft je 1-fase aansluiting?</Text>
 
       {/* 16A verwijst naar vast 5 kWh advies → geen aansluiting nodig */}
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Advies 5 kWh')}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() =>
+          navigation.navigate('Advies 5 kWh', {
+            aansluiting,
+            clientType,
+            zekering: '16A',
+            adviesCapacity: '5 kWh batterijopslag',
+          })
+        }
+      >
         <Text style={styles.buttonText}>16A</Text>
       </TouchableOpacity>
 
       {/* Deze twee verwijzen naar Persoonsgegevens + aansluiting meesturen */}
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting })}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting, clientType, zekering: '25A' })}
+      >
         <Text style={styles.buttonText}>25A</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting })}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting, clientType, zekering: '32A' })}
+      >
         <Text style={styles.buttonText}>32A</Text>
       </TouchableOpacity>
     </View>

--- a/screens/Fase3ZekeringScreen.js
+++ b/screens/Fase3ZekeringScreen.js
@@ -5,20 +5,30 @@ import { useRoute } from '@react-navigation/native';
 export default function Fase3ZekeringScreen({ navigation }) {
   const route = useRoute();
   const aansluiting = route.params?.aansluiting || '3-fase';
+  const clientType = route.params?.clientType || 'Particulier';
 
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Welke zekering heeft je 3-fase aansluiting?</Text>
 
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting })}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting, clientType, zekering: '16A' })}
+      >
         <Text style={styles.buttonText}>16A</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting })}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting, clientType, zekering: '25A' })}
+      >
         <Text style={styles.buttonText}>25A</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting })}>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => navigation.navigate('Persoonsgegevens', { aansluiting, clientType, zekering: '32A' })}
+      >
         <Text style={styles.buttonText}>32A</Text>
       </TouchableOpacity>
     </View>

--- a/screens/OverzichtZakelijkAdviesScreen.js
+++ b/screens/OverzichtZakelijkAdviesScreen.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
 export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
   const { kwh1, kwh2, energiehandel } = route.params;
@@ -19,6 +21,27 @@ export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
   // Kies eerste optie die groter of gelijk is aan totaalbehoefte
   const gekozen = zakelijkeOpties.find(optie => kwhTotaal <= optie.capaciteit) || { naam: 'Meer dan 20 kWh nodig', afbeelding: null };
 
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Zakelijk', company: route?.params?.clientCompany },
+        advice: {
+          title: 'Zakelijk Advies',
+          summary: `Benodigd totaal: ${kwhTotaal.toFixed(1)} kWh`,
+          capacity: gekozen.naam,
+          connection: route?.params?.aansluiting ?? '—',
+          image: gekozen.afbeelding,
+          inputs: {
+            verbruik: kwhTotaal.toFixed(1),
+            overige: energiehandel ? `Energiehandel: ${energiehandel}` : undefined,
+          },
+        },
+        reference: { prefix: 'ZAK-OVZ' },
+      }),
+    [energiehandel, gekozen.afbeelding, gekozen.naam, kwhTotaal, route?.params]
+  );
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Zakelijk Advies</Text>
@@ -33,6 +56,8 @@ export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
       {energiehandel && (
         <Text style={styles.subtext}>Energiehandel gewenst: {energiehandel}</Text>
       )}
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Home')}>
         <Text style={styles.buttonText}>Terug naar begin</Text>
@@ -69,5 +94,8 @@ const styles = StyleSheet.create({
   buttonText: {
     color: '#fff',
     fontSize: 18
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/ParticulierScreen.js
+++ b/screens/ParticulierScreen.js
@@ -1,34 +1,28 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 
-export default function ParticulierScreen({ navigation }) {
+export default function ParticulierScreen({ navigation, route }) {
+  const clientType = route?.params?.clientType || 'Particulier';
+
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Wat voor aansluiting heb je thuis?</Text>
 
       <TouchableOpacity
         style={styles.button}
-        onPress={() => navigation.navigate('Fase 1')}
+        onPress={() => navigation.navigate('Fase 1', { clientType, aansluiting: '1-fase' })}
       >
         <Text style={styles.buttonText}>1-fase aansluiting</Text>
       </TouchableOpacity>
-      <TouchableOpacity onPress={() => navigation.navigate('Fase 1', { aansluiting: '1-fase' })}>
- 
-</TouchableOpacity>
-
-<TouchableOpacity onPress={() => navigation.navigate('Fase 3', { aansluiting: '3-fase' })}>
-
-</TouchableOpacity>
-
 
       <TouchableOpacity
         style={styles.button}
-        onPress={() => navigation.navigate('Fase 3')}
+        onPress={() => navigation.navigate('Fase 3', { clientType, aansluiting: '3-fase' })}
       >
         <Text style={styles.buttonText}>3-fase aansluiting</Text>
       </TouchableOpacity>
     </View>
-    
+
   );
 }
 

--- a/screens/PersoonsgegevensScreen.js
+++ b/screens/PersoonsgegevensScreen.js
@@ -5,6 +5,8 @@ import { useRoute } from '@react-navigation/native';
 export default function PersoonsgegevensScreen({ navigation }) {
   const route = useRoute();
   const aansluiting = route.params?.aansluiting;
+  const clientType = route.params?.clientType || 'Particulier';
+  const zekering = route.params?.zekering || '—';
 
   const [verbruik, setVerbruik] = useState('');
   const [vermogenWp, setVermogenWp] = useState('');
@@ -15,7 +17,9 @@ export default function PersoonsgegevensScreen({ navigation }) {
       verbruik,
       vermogenWp,
       aantalPanelen,
-      aansluiting
+      aansluiting,
+      clientType,
+      zekering,
     });
   };
 

--- a/screens/Step1Screen.js
+++ b/screens/Step1Screen.js
@@ -8,14 +8,14 @@ export default function Step2Screen({ navigation }) {
 
       <TouchableOpacity
         style={styles.button}
-onPress={() => navigation.navigate('Particulier')}
+        onPress={() => navigation.navigate('Particulier', { clientType: 'Particulier' })}
       >
         <Text style={styles.buttonText}>Particulier</Text>
       </TouchableOpacity>
 
       <TouchableOpacity
         style={styles.button}
-onPress={() => navigation.navigate('ZakelijkDoel')}
+        onPress={() => navigation.navigate('ZakelijkDoel', { clientType: 'Zakelijk' })}
       >
         <Text style={styles.buttonText}>Zakelijk</Text>
       </TouchableOpacity>

--- a/screens/ZakelijkAdviesHandelScreen.js
+++ b/screens/ZakelijkAdviesHandelScreen.js
@@ -1,4 +1,7 @@
+import React, { useMemo } from 'react';
 import { Text, StyleSheet, Image, ScrollView, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
 export default function ZakelijkAdviesHandelScreen({ navigation, route }) {
   const { kwh1, kwh2 = 0 } = route.params;
@@ -31,6 +34,27 @@ export default function ZakelijkAdviesHandelScreen({ navigation, route }) {
     image = require('../assets/5-MW-ZAKELIJK.png');
   }
 
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Zakelijk', company: route?.params?.clientCompany },
+        advice: {
+          title: 'Advies: Handel op energiemarkten',
+          summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(1)} kWh`,
+          capacity: advies,
+          connection: 'Hoog voltage',
+          image,
+          inputs: {
+            verbruik: totaleBehoefte.toFixed(1),
+            overige: `kWh invoer: ${kwh1}, ${kwh2}`,
+          },
+        },
+        reference: { prefix: 'ZAK-HAN' },
+      }),
+    [advies, image, kwh1, kwh2, route?.params, totaleBehoefte]
+  );
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Advies: Handel op energiemarkten</Text>
@@ -40,6 +64,8 @@ export default function ZakelijkAdviesHandelScreen({ navigation, route }) {
       {image && (
         <Image source={image} style={styles.image} resizeMode="contain" />
       )}
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity
         style={styles.button}
@@ -59,4 +85,7 @@ const styles = StyleSheet.create({
   image: { width: '100%', height: 250, marginVertical: 20 },
   button: { backgroundColor: '#f7941e', padding: 14, borderRadius: 10, width: '100%', alignItems: 'center' },
   buttonText: { color: '#fff', fontSize: 16 },
+  emailButton: {
+    marginTop: 24,
+  },
 });

--- a/screens/ZakelijkAdviesLoadShiftingScreen.js
+++ b/screens/ZakelijkAdviesLoadShiftingScreen.js
@@ -1,6 +1,8 @@
 // screens/ZakelijkAdviesLoadShiftingScreen.js
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
 export default function ZakelijkAdviesLoadShiftingScreen({ route, navigation }) {
   const { kwh1 = 0, kwh2 = 0, kwh3 = 0 } = route.params;
@@ -32,6 +34,27 @@ export default function ZakelijkAdviesLoadShiftingScreen({ route, navigation }) 
     image = require('../assets/5-MW-ZAKELIJK.png');
   }
 
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Zakelijk', company: route?.params?.clientCompany },
+        advice: {
+          title: 'Advies Load Shifting',
+          summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(1)} kWh`,
+          capacity: advies,
+          connection: 'Hoog voltage',
+          image,
+          inputs: {
+            verbruik: totaleBehoefte.toFixed(1),
+            overige: `kWh invoer: ${kwh1}, ${kwh2}, ${kwh3}`,
+          },
+        },
+        reference: { prefix: 'ZAK-LS' },
+      }),
+    [advies, image, kwh1, kwh2, kwh3, route?.params, totaleBehoefte]
+  );
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Advies Load Shifting</Text>
@@ -41,6 +64,8 @@ export default function ZakelijkAdviesLoadShiftingScreen({ route, navigation }) 
       {image && (
         <Image source={image} style={styles.image} resizeMode="contain" />
       )}
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('ZakelijkDoel')}>
         <Text style={styles.buttonText}>Terug naar Start</Text>
@@ -85,5 +110,8 @@ const styles = StyleSheet.create({
   buttonText: {
     color: '#fff',
     fontSize: 16,
+  },
+  emailButton: {
+    marginTop: 24,
   },
 });

--- a/screens/ZakelijkAdviesNetcongestie.js
+++ b/screens/ZakelijkAdviesNetcongestie.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
 export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
   const { kwh1, kwh2 = 0, kwh3 = 0 } = route.params;
@@ -25,6 +27,27 @@ export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
     image = require('../assets/5-MW-ZAKELIJK.png');
   }
 
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Zakelijk', company: route?.params?.clientCompany },
+        advice: {
+          title: 'Advies Netcongestie',
+          summary: `Benodigd vermogen: ${totaleBehoefte.toFixed(2)} kWh`,
+          capacity: advies,
+          connection: 'Hoog voltage',
+          image,
+          inputs: {
+            verbruik: totaleBehoefte.toFixed(2),
+            overige: `kWh invoer: ${kwh1}, ${kwh2}, ${kwh3}`,
+          },
+        },
+        reference: { prefix: 'ZAK-NC' },
+      }),
+    [advies, image, kwh1, kwh2, kwh3, route?.params, totaleBehoefte]
+  );
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Advies op maat</Text>
@@ -32,6 +55,8 @@ export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
       <Text style={styles.text}>Aanbevolen oplossing: {advies}</Text>
 
       {image && <Image source={image} style={styles.image} resizeMode="contain" />}
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.buttonText}>Bekijk specificaties</Text>
@@ -77,5 +102,8 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
+  },
+  emailButton: {
+    marginTop: 24,
   },
 });

--- a/screens/ZakelijkAdviesNoodstroom.js
+++ b/screens/ZakelijkAdviesNoodstroom.js
@@ -1,6 +1,8 @@
 // screens/ZakelijkAdviesNoodstroom.js
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ScrollView } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
 export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
   const { kwh1, kwh2 } = route.params;
@@ -26,6 +28,27 @@ export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
     afbeelding = require('../assets/5-MW-ZAKELIJK.png');
   }
 
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Zakelijk', company: route?.params?.clientCompany },
+        advice: {
+          title: 'Advies Noodstroomvoorziening',
+          summary: `Benodigde opslagcapaciteit: ${totaalKwh.toFixed(1)} kWh`,
+          capacity: advies,
+          connection: 'Hoog voltage',
+          image: afbeelding,
+          inputs: {
+            verbruik: totaalKwh.toFixed(1),
+            overige: `kWh invoer: ${kwh1}, ${kwh2}`,
+          },
+        },
+        reference: { prefix: 'ZAK-NS' },
+      }),
+    [afbeelding, advies, kwh1, kwh2, route?.params, totaalKwh]
+  );
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Advies Noodstroomvoorziening</Text>
@@ -33,6 +56,8 @@ export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
       <Text style={styles.result}>Aanbevolen oplossing: {advies}</Text>
 
       <Image source={afbeelding} style={styles.image} resizeMode="contain" />
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity
         style={styles.button}
@@ -81,5 +106,8 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 16,
     fontWeight: '600'
+  },
+  emailButton: {
+    marginTop: 24,
   }
 });

--- a/screens/ZakelijkAdviesPeakScreen.js
+++ b/screens/ZakelijkAdviesPeakScreen.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Image } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
 export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
   const { kwh1, kwh2 = 0, kwh3 = 0 } = route.params;
@@ -29,6 +31,27 @@ export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
     image = require('../assets/5-MW-ZAKELIJK.png');
   }
 
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Zakelijk', company: route?.params?.clientCompany },
+        advice: {
+          title: 'Peak Shaving advies',
+          summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(1)} kWh`,
+          capacity: advies,
+          connection: 'Hoog voltage',
+          image,
+          inputs: {
+            verbruik: totaleBehoefte.toFixed(1),
+            overige: `kWh invoer: ${kwh1}, ${kwh2}, ${kwh3}`,
+          },
+        },
+        reference: { prefix: 'ZAK-PEAK' },
+      }),
+    [advies, image, kwh1, kwh2, kwh3, route?.params, totaleBehoefte]
+  );
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Advies op maat</Text>
@@ -38,6 +61,8 @@ export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
       {image && (
         <Image source={image} style={styles.image} resizeMode="contain" />
       )}
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity
         style={styles.button}
@@ -91,5 +116,8 @@ const styles = StyleSheet.create({
   buttonText: {
     color: '#fff',
     fontSize: 16,
+  },
+  emailButton: {
+    marginTop: 24,
   },
 });

--- a/screens/ZakelijkAdviesScreen.js
+++ b/screens/ZakelijkAdviesScreen.js
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import AdviceEmailButton from '../components/AdviceEmailButton';
+import { createAdvicePayload } from '../utils/createAdvicePayload';
 
 export default function ZakelijkAdviesScreen({ navigation, route }) {
   const { kwh1, kwh2, kwh3 } = route.params;
@@ -26,6 +28,27 @@ export default function ZakelijkAdviesScreen({ navigation, route }) {
     image = require('../assets/5-MW-ZAKELIJK.png');
   }
 
+  const emailPayload = useMemo(
+    () =>
+      createAdvicePayload({
+        routeParams: route?.params,
+        client: { type: 'Zakelijk', company: route?.params?.clientCompany },
+        advice: {
+          title: 'Zakelijk advies op maat',
+          summary: `Benodigd vermogen: ${k0.toFixed(2)} kWh`,
+          capacity: advies,
+          connection: 'Hoog voltage',
+          image,
+          inputs: {
+            verbruik: k0.toFixed(2),
+            overige: `Invoer kWh: ${kwh1}, ${kwh2}, ${kwh3}`,
+          },
+        },
+        reference: { prefix: 'ZAK-ADV' },
+      }),
+    [advies, image, k0, kwh1, kwh2, kwh3, route?.params]
+  );
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Advies op maat</Text>
@@ -33,6 +56,8 @@ export default function ZakelijkAdviesScreen({ navigation, route }) {
       <Text style={styles.text}>Aanbevolen oplossing: {advies}</Text>
 
       {image && <Image source={image} style={styles.image} resizeMode="contain" />}
+
+      <AdviceEmailButton payload={emailPayload} style={styles.emailButton} />
 
       <TouchableOpacity style={styles.button} onPress={() => navigation.navigate('Specificaties')}>
         <Text style={styles.buttonText}>Bekijk specificaties</Text>
@@ -78,5 +103,8 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 16,
     fontWeight: '600',
+  },
+  emailButton: {
+    marginTop: 24,
   },
 });

--- a/utils/createAdvicePayload.js
+++ b/utils/createAdvicePayload.js
@@ -1,0 +1,102 @@
+const defaultLogo = require('../assets/logo.png');
+
+const sanitize = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return '—';
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? `${value}` : '—';
+  }
+
+  return `${value}`;
+};
+
+const toIsoString = (value) => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+
+  return new Date().toISOString();
+};
+
+const generateReferenceId = (prefix = 'ADV') => {
+  const timestamp = new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 12);
+  return `${prefix}-${timestamp}`;
+};
+
+export function createAdvicePayload({
+  routeParams = {},
+  client = {},
+  advice = {},
+  reference = {},
+  logos,
+}) {
+  const mergedParams = routeParams || {};
+
+  const normalizedClient = {
+    type: sanitize(mergedParams.clientType ?? client.type),
+    name: sanitize(mergedParams.clientName ?? client.name),
+    company: sanitize(mergedParams.clientCompany ?? client.company),
+    email: sanitize(mergedParams.clientEmail ?? client.email),
+    phone: sanitize(mergedParams.clientPhone ?? client.phone),
+  };
+
+  const normalizedAdvice = {
+    title: sanitize(advice.title ?? mergedParams.adviceTitle),
+    summary: sanitize(advice.summary ?? mergedParams.adviceSummary),
+    capacity: sanitize(advice.capacity ?? mergedParams.adviceCapacity),
+    connection: sanitize(
+      mergedParams.aansluiting ?? advice.connection ?? mergedParams.connection
+    ),
+    inputs: {
+      verbruik: sanitize(advice.inputs?.verbruik ?? mergedParams.verbruik),
+      vermogenWp: sanitize(advice.inputs?.vermogenWp ?? mergedParams.vermogenWp),
+      aantalPanelen: sanitize(
+        advice.inputs?.aantalPanelen ?? mergedParams.aantalPanelen
+      ),
+      overige: sanitize(
+        advice.inputs?.overige ??
+          mergedParams.overige ??
+          (mergedParams.zekering ? `Zekering: ${mergedParams.zekering}` : undefined)
+      ),
+    },
+    image: advice.image ?? mergedParams.adviceImage ?? null,
+  };
+
+  const referenceId =
+    reference.id ?? mergedParams.referenceId ?? generateReferenceId(reference.prefix);
+  const referenceDate =
+    reference.date ?? mergedParams.referenceDate ?? toIsoString(reference.createdAt);
+
+  const providedLogos = logos || mergedParams.logos || advice.logos;
+  const normalizedLogos = Array.isArray(providedLogos) && providedLogos.length
+    ? providedLogos
+    : [defaultLogo];
+
+  return {
+    client: normalizedClient,
+    advice: normalizedAdvice,
+    reference: {
+      id: referenceId,
+      date: referenceDate,
+    },
+    logos: normalizedLogos,
+    attachments: advice.attachments ?? mergedParams.attachments ?? [],
+    __isNormalizedAdvicePayload: true,
+  };
+}
+
+export function formatReferenceDate(dateValue) {
+  try {
+    const date = new Date(dateValue);
+    return date.toLocaleDateString('nl-NL');
+  } catch (error) {
+    return sanitize(dateValue);
+  }
+}
+

--- a/utils/sendAdviceByEmail.js
+++ b/utils/sendAdviceByEmail.js
@@ -1,0 +1,187 @@
+import * as MailComposer from 'expo-mail-composer';
+import { Image, Linking, Share } from 'react-native';
+import { createAdvicePayload, formatReferenceDate } from './createAdvicePayload';
+
+const isFilled = (value) => value && value !== '—';
+
+const buildEmailSubject = (payload) => {
+  const subjectParts = ['WattsNext advies'];
+
+  if (isFilled(payload.advice?.capacity)) {
+    subjectParts.push(`– ${payload.advice.capacity}`);
+  }
+
+  if (isFilled(payload.client?.name)) {
+    subjectParts.push(`voor ${payload.client.name}`);
+  }
+
+  if (isFilled(payload.reference?.id)) {
+    subjectParts.push(`(${payload.reference.id})`);
+  }
+
+  return subjectParts.join(' ');
+};
+
+const buildAdviceLines = (payload) => {
+  const lines = [];
+  const { advice } = payload;
+
+  lines.push(`Samenvatting: ${advice.summary}`);
+  lines.push(`Capaciteit: ${advice.capacity}`);
+  lines.push(`Aansluiting: ${advice.connection}`);
+
+  const inputs = advice.inputs || {};
+  lines.push(`Jaarverbruik: ${inputs.verbruik}`);
+  lines.push(`Vermogen per paneel: ${inputs.vermogenWp}`);
+  lines.push(`Aantal panelen: ${inputs.aantalPanelen}`);
+
+  if (isFilled(inputs.overige)) {
+    lines.push(`Overige gegevens: ${inputs.overige}`);
+  }
+
+  return lines;
+};
+
+const buildClientLines = (payload) => {
+  const { client } = payload;
+  return [
+    `Type klant: ${client.type}`,
+    `Naam: ${client.name}`,
+    `Bedrijf: ${client.company}`,
+    `E-mail: ${client.email}`,
+    `Telefoon: ${client.phone}`,
+  ];
+};
+
+const buildEmailBody = (payload) => {
+  const subject = buildEmailSubject(payload);
+  const bodyLines = [
+    `Beste ${isFilled(payload.client?.name) ? payload.client.name : 'relatie'},`,
+    '',
+    'Hierbij het aangevraagde advies van WattsNext.',
+    '',
+    'Klantgegevens:',
+    ...buildClientLines(payload),
+    '',
+    'Adviesdetails:',
+    ...buildAdviceLines(payload),
+    '',
+    `Referentie: ${payload.reference.id}`,
+    `Datum: ${formatReferenceDate(payload.reference.date)}`,
+  ];
+
+  if (payload.logos && payload.logos.length > 0) {
+    bodyLines.push('');
+    bodyLines.push(`Logo's in deze mail: ${payload.logos.length}`);
+  }
+
+  bodyLines.push('');
+  bodyLines.push('Met vriendelijke groet,');
+  bodyLines.push('WattsNext Advies');
+
+  return { subject, body: bodyLines.join('\n') };
+};
+
+const resolveMediaAttachments = async (media) => {
+  if (!media || !media.length) {
+    return [];
+  }
+
+  const resolved = media
+    .map((item) => {
+      try {
+        if (!item) {
+          return null;
+        }
+
+        if (typeof item === 'string') {
+          return item;
+        }
+
+        if (typeof item === 'object' && item.uri) {
+          return item.uri;
+        }
+
+        const assetSource = Image.resolveAssetSource(item);
+        return assetSource?.uri ?? null;
+      } catch (error) {
+        console.warn('sendAdviceByEmail: attachment kon niet geladen worden', error);
+        return null;
+      }
+    })
+    .filter((uri) => typeof uri === 'string');
+
+  return resolved;
+};
+
+export async function sendAdviceByEmail(rawPayload, options = {}) {
+  const payload = rawPayload?.__isNormalizedAdvicePayload
+    ? rawPayload
+    : createAdvicePayload(rawPayload);
+  const { subject, body } = buildEmailBody(payload);
+
+  let composerAvailable = false;
+
+  try {
+    composerAvailable = await MailComposer.isAvailableAsync();
+  } catch (error) {
+    composerAvailable = false;
+  }
+
+  if (composerAvailable) {
+    const attachments = await resolveMediaAttachments([
+      ...(payload.logos || []),
+      ...(payload.attachments || []),
+      payload.advice?.image,
+    ].filter(Boolean));
+
+    options?.onComposerOpen?.();
+
+    const result = await MailComposer.composeAsync({
+      subject,
+      body,
+      attachments,
+    });
+
+    return {
+      method: 'composer',
+      result,
+      subject,
+      body,
+    };
+  }
+
+  const shareMessage = `${subject}\n\n${body}`;
+
+  try {
+    await Share.share({
+      message: shareMessage,
+      title: subject,
+    });
+
+    return {
+      method: 'share',
+      subject,
+      body,
+    };
+  } catch (shareError) {
+    const mailtoUrl = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
+    try {
+      const canOpen = await Linking.canOpenURL(mailtoUrl);
+      if (canOpen) {
+        await Linking.openURL(mailtoUrl);
+        return {
+          method: 'mailto',
+          subject,
+          body,
+        };
+      }
+    } catch (linkError) {
+      throw linkError;
+    }
+
+    throw shareError;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a shared AdviceEmailButton that triggers the new sendAdviceByEmail helper with loading and feedback behaviour
- collect advice payload data with createAdvicePayload and propagate inputs across the different advice navigation flows
- render the email button on all advice variants, including business views, and show structured fallback messages

## Testing
- npm install *(fails: 403 Forbidden when downloading expo-mail-composer in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9ed91adc832c85b1f13389196a75