### PR TITLE
Add saved advice buttons and overview screen

### DIFF
--- a/App.js
+++ b/App.js
@@ -54,6 +54,7 @@ import Spec_LV_particulier from './screens/Spec_LV_particulier';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
 import AccountBeherenScreen from './screens/AccountBeherenScreen';
+import SavedAdvicesScreen from './screens/SavedAdvicesScreen';
 import Toast from 'react-native-toast-message';
 
 const Stack = createNativeStackNavigator();
@@ -65,6 +66,7 @@ export default function App() {
         <Stack.Screen name="LoginScreen" component={LoginScreen} options={{ headerShown: false }} />
         <Stack.Screen name="RegisterScreen" component={RegisterScreen} />
         <Stack.Screen name="HomeScreen" component={HomeScreen} />
+        <Stack.Screen name="SavedAdvices" component={SavedAdvicesScreen} />
         <Stack.Screen name="Stap 1" component={Step1Screen} />
         <Stack.Screen name="Particulier" component={ParticulierScreen} />
         <Stack.Screen name="Fase 1" component={Fase1Screen} />

--- a/components/SaveAdviceButton.js
+++ b/components/SaveAdviceButton.js
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { Alert, ActivityIndicator, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const SAVED_ADVICES_STORAGE_KEY = '@wattsnext/saved_advices';
+
+export default function SaveAdviceButton({ advice, label = 'Bewaar advies', style, textStyle }) {
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (!advice || !advice.id) {
+      Alert.alert('Opslaan niet mogelijk', 'Advies mist een id en kan niet opgeslagen worden.');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const raw = await AsyncStorage.getItem(SAVED_ADVICES_STORAGE_KEY);
+      const stored = raw ? JSON.parse(raw) : [];
+      const timestamp = new Date().toISOString();
+
+      const existingIndex = stored.findIndex(item => item.id === advice.id);
+      let updated = [];
+
+      if (existingIndex > -1) {
+        updated = [...stored];
+        const previous = updated[existingIndex];
+        updated[existingIndex] = {
+          ...previous,
+          ...advice,
+          savedAt: previous.savedAt || timestamp,
+          updatedAt: timestamp,
+        };
+      } else {
+        updated = [...stored, { ...advice, savedAt: timestamp }];
+      }
+
+      await AsyncStorage.setItem(SAVED_ADVICES_STORAGE_KEY, JSON.stringify(updated));
+      Alert.alert('Advies opgeslagen', existingIndex > -1 ? 'Het advies is bijgewerkt in je overzicht.' : 'Het advies is toegevoegd aan je overzicht.');
+    } catch (error) {
+      console.error('Advies opslaan mislukt', error);
+      Alert.alert('Opslaan mislukt', 'Er ging iets mis bij het opslaan. Probeer het later opnieuw.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      onPress={handleSave}
+      style={[styles.button, style]}
+      disabled={saving}
+    >
+      {saving ? (
+        <ActivityIndicator color="#fff" />
+      ) : (
+        <Text style={[styles.buttonText, textStyle]}>{label}</Text>
+      )}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    marginTop: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    backgroundColor: '#1f6f34',
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: 180,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/screens/Advies10Hoog.js
+++ b/screens/Advies10Hoog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies10Hoog({ navigation }) {
   return (
@@ -28,6 +29,14 @@ export default function Advies10Hoog({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-10kwh-hoog',
+              title: 'Advies 10 kWh (Hoog Voltage)',
+              summary: 'Advies voor 10 kWh batterijopslag met hoog voltage configuratie.',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/Advies10Laag.js
+++ b/screens/Advies10Laag.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies10Laag({ navigation }) {
   return (
@@ -30,6 +31,14 @@ export default function Advies10Laag({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-10kwh-laag',
+              title: 'Advies 10 kWh (Laag Voltage)',
+              summary: 'Advies voor 10 kWh batterijopslag met laag voltage configuratie.',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/Advies12_5Hoog.js
+++ b/screens/Advies12_5Hoog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies12_5Hoog({ navigation }) {
   return (
@@ -28,6 +29,14 @@ export default function Advies12_5Hoog({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-12_5kwh-hoog',
+              title: 'Advies 12,5 kWh (Hoog Voltage)',
+              summary: 'Advies voor 12,5 kWh batterijopslag met hoog voltage configuratie.',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/Advies15Hoog.js
+++ b/screens/Advies15Hoog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies15Hoog({ navigation }) {
   return (
@@ -28,6 +29,14 @@ export default function Advies15Hoog({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-15kwh-hoog',
+              title: 'Advies 15 kWh (Hoog Voltage)',
+              summary: 'Advies voor 15 kWh batterijopslag met hoog voltage configuratie.',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/Advies17_5Hoog.js
+++ b/screens/Advies17_5Hoog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies17_5Hoog({ navigation }) {
   return (
@@ -28,6 +29,14 @@ export default function Advies17_5Hoog({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-17_5kwh-hoog',
+              title: 'Advies 17,5 kWh (Hoog Voltage)',
+              summary: 'Advies voor 17,5 kWh batterijopslag met hoog voltage configuratie.',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/Advies20Hoog.js
+++ b/screens/Advies20Hoog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies20Hoog({ navigation }) {
   return (
@@ -28,6 +29,14 @@ export default function Advies20Hoog({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-20kwh-hoog',
+              title: 'Advies 20 kWh (Hoog Voltage)',
+              summary: 'Advies voor 20 kWh batterijopslag met hoog voltage configuratie.',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/Advies5kWhScreen.js
+++ b/screens/Advies5kWhScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies5kWhScreen({ navigation }) {
   return (
@@ -31,6 +32,15 @@ export default function Advies5kWhScreen({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-5kwh',
+              title: 'Advies 5 kWh',
+              summary:
+                '1-fase aansluiting met een 16A zekering en advies voor 5 kWh batterijopslag (Laag Voltage).',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/Advies7_5Hoog.js
+++ b/screens/Advies7_5Hoog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function Advies7_5Hoog({ navigation }) {
   return (
@@ -30,6 +31,14 @@ export default function Advies7_5Hoog({ navigation }) {
           >
             <Text style={styles.specButtonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: 'particulier-7_5kwh-hoog',
+              title: 'Advies 7,5 kWh (Hoog Voltage)',
+              summary: 'Advies voor 7,5 kWh batterijopslag met hoog voltage configuratie.',
+            }}
+          />
         </View>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -78,6 +78,17 @@ export default function HomeScreen({ navigation }) {
               Account beheren
             </Text>
           </TouchableOpacity>
+
+          <View style={{ height: 16 }} />
+
+          <TouchableOpacity
+            style={[styles.secondaryButton, { width: width > 768 ? 300 : '80%' }]}
+            onPress={() => navigation.navigate('SavedAdvices')}
+            accessibilityRole="button"
+            accessibilityLabel="Bekijk opgeslagen adviezen"
+          >
+            <Text style={[styles.secondaryButtonText, { fontSize: width > 768 ? 18 : 16 }]}>Opgeslagen adviezen</Text>
+          </TouchableOpacity>
         </View>
       </SafeAreaView>
     </View>

--- a/screens/OverzichtZakelijkAdviesScreen.js
+++ b/screens/OverzichtZakelijkAdviesScreen.js
@@ -11,6 +11,7 @@ import {
   Linking,
   Alert,
 } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
   const { kwh1, kwh2, energiehandel } = route.params;
@@ -33,6 +34,14 @@ export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
     naam: 'Meer dan 20 kWh nodig',
     afbeelding: null,
   };
+
+  const adviesId = useMemo(() => {
+    if (!gekozen.naam) {
+      return 'zakelijk-overzicht';
+    }
+
+    return `zakelijk-overzicht-${gekozen.naam.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+  }, [gekozen.naam]);
 
   const emailSubject = useMemo(
     () => 'Afspraak inplannen - Wattsnext zakelijk advies',
@@ -106,6 +115,16 @@ export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
               Energiehandel gewenst: {energiehandel}
             </Text>
           )}
+
+          <SaveAdviceButton
+            advice={{
+              id: adviesId,
+              title: `Zakelijk advies overzicht: ${gekozen.naam}`,
+              summary: `Totaal vermogen: ${kwhTotaal.toFixed(1)} kWh.${
+                energiehandel ? ` Energiehandel: ${energiehandel}.` : ''
+              }`,
+            }}
+          />
 
           <TouchableOpacity
             style={[styles.button, styles.emailButton]}

--- a/screens/SavedAdvicesScreen.js
+++ b/screens/SavedAdvicesScreen.js
@@ -1,0 +1,196 @@
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  ImageBackground,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useFocusEffect } from '@react-navigation/native';
+import { SAVED_ADVICES_STORAGE_KEY } from '../components/SaveAdviceButton';
+
+function formatTimestamp(value) {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${day}-${month}-${year} ${hours}:${minutes}`;
+}
+
+export default function SavedAdvicesScreen() {
+  const [advices, setAdvices] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const loadAdvices = useCallback(async () => {
+    try {
+      setLoading(true);
+      const raw = await AsyncStorage.getItem(SAVED_ADVICES_STORAGE_KEY);
+      if (!raw) {
+        setAdvices([]);
+        return;
+      }
+
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        const sorted = [...parsed].sort((a, b) => {
+          const timeA = new Date(a.updatedAt || a.savedAt || 0).getTime();
+          const timeB = new Date(b.updatedAt || b.savedAt || 0).getTime();
+          return timeB - timeA;
+        });
+        setAdvices(sorted);
+      } else {
+        setAdvices([]);
+      }
+    } catch (error) {
+      console.error('Adviezen ophalen mislukt', error);
+      setAdvices([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadAdvices();
+    }, [loadAdvices])
+  );
+
+  const renderAdvice = ({ item }) => (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>{item.title}</Text>
+      {item.summary ? <Text style={styles.cardSummary}>{item.summary}</Text> : null}
+      {item.savedAt ? (
+        <Text style={styles.cardDate}>
+          Opgeslagen op: {formatTimestamp(item.updatedAt || item.savedAt)}
+        </Text>
+      ) : null}
+    </View>
+  );
+
+  return (
+    <ImageBackground
+      source={require('../assets/achtergrond.png')}
+      style={styles.background}
+      resizeMode="contain"
+      imageStyle={styles.imageStyle}
+    >
+      <SafeAreaView style={{ flex: 1 }}>
+        <View style={styles.container}>
+          <Text style={styles.title}>Opgeslagen adviezen</Text>
+          <Text style={styles.subtitle}>
+            Bewaar adviezen via de knoppen op de adviesschermen en bekijk ze hier terug.
+          </Text>
+
+          {loading ? (
+            <ActivityIndicator size="large" color="#f7941e" style={styles.loader} />
+          ) : advices.length === 0 ? (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyTitle}>Nog geen adviezen opgeslagen</Text>
+              <Text style={styles.emptyText}>
+                Keer terug naar het advies en gebruik de knop "Bewaar advies" om het op te slaan.
+              </Text>
+            </View>
+          ) : (
+            <FlatList
+              data={advices}
+              keyExtractor={item => item.id}
+              renderItem={renderAdvice}
+              contentContainerStyle={styles.listContent}
+            />
+          )}
+        </View>
+      </SafeAreaView>
+    </ImageBackground>
+  );
+}
+
+const styles = StyleSheet.create({
+  background: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  imageStyle: {
+    resizeMode: 'contain',
+    position: 'absolute',
+    width: '100%',
+    height: '100%',
+  },
+  container: {
+    flex: 1,
+    padding: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#3eaf4f',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  loader: {
+    marginTop: 32,
+  },
+  emptyState: {
+    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+    borderRadius: 12,
+    padding: 24,
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 8,
+    color: '#3eaf4f',
+  },
+  emptyText: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: '#333',
+  },
+  listContent: {
+    paddingBottom: 24,
+    gap: 16,
+  },
+  card: {
+    backgroundColor: 'rgba(255, 255, 255, 0.95)',
+    borderRadius: 12,
+    padding: 20,
+  },
+  cardTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#1f6f34',
+    marginBottom: 8,
+  },
+  cardSummary: {
+    fontSize: 16,
+    color: '#333',
+    marginBottom: 6,
+  },
+  cardDate: {
+    fontSize: 14,
+    color: '#666',
+  },
+});

--- a/screens/ZakelijkAdviesHandelScreen.js
+++ b/screens/ZakelijkAdviesHandelScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function ZakelijkAdviesHandelScreen({ route, navigation }) {
   const { kwh1, kwh2 = 0 } = route.params;
@@ -52,6 +53,14 @@ export default function ZakelijkAdviesHandelScreen({ route, navigation }) {
           >
             <Text style={styles.buttonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: `zakelijk-handel-${specificatieScreen}`,
+              title: `Energiehandel advies: ${advies}`,
+              summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(2)} kWh. Aanbevolen oplossing: ${advies}.`,
+            }}
+          />
         </ScrollView>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/ZakelijkAdviesLoadShiftingScreen.js
+++ b/screens/ZakelijkAdviesLoadShiftingScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function ZakelijkAdviesLoadShiftingScreen({ route, navigation }) {
   const { kwh1 = 0, kwh2 = 0, kwh3 = 0 } = route.params;
@@ -67,6 +68,14 @@ export default function ZakelijkAdviesLoadShiftingScreen({ route, navigation }) 
           >
             <Text style={styles.buttonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: `zakelijk-loadshifting-${specificatieScreen}`,
+              title: `Load Shifting advies: ${advies}`,
+              summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(1)} kWh. Aanbevolen oplossing: ${advies}.`,
+            }}
+          />
         </ScrollView>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/ZakelijkAdviesNetcongestie.js
+++ b/screens/ZakelijkAdviesNetcongestie.js
@@ -7,8 +7,9 @@ import {
   ScrollView,
   TouchableOpacity,
   ImageBackground,
-  SafeAreaView
+  SafeAreaView,
 } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
   const { kwh1, kwh2 = 0, kwh3 = 0 } = route.params;
@@ -70,6 +71,14 @@ export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
           >
             <Text style={styles.buttonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: `zakelijk-netcongestie-${specificatieScreen}`,
+              title: `Netcongestie advies: ${advies}`,
+              summary: `Benodigd vermogen: ${totaleBehoefte.toFixed(2)} kWh. Aanbevolen oplossing: ${advies}.`,
+            }}
+          />
         </ScrollView>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/ZakelijkAdviesNoodstroom.js
+++ b/screens/ZakelijkAdviesNoodstroom.js
@@ -9,6 +9,7 @@ import {
   ImageBackground,
   SafeAreaView,
 } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
   const { kwh1, kwh2 } = route.params;
@@ -70,6 +71,14 @@ export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
           >
             <Text style={styles.buttonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: `zakelijk-noodstroom-${specificatieScreen}`,
+              title: `Noodstroom advies: ${advies}`,
+              summary: `Benodigde opslagcapaciteit: ${totaalKwh.toFixed(1)} kWh. Aanbevolen oplossing: ${advies}.`,
+            }}
+          />
         </ScrollView>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/ZakelijkAdviesPeakScreen.js
+++ b/screens/ZakelijkAdviesPeakScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Image, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
   const { kwh1, kwh2 = 0, kwh3 = 0 } = route.params;
@@ -75,6 +76,14 @@ export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
           >
             <Text style={styles.buttonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: `zakelijk-peak-${specificatieScreen}`,
+              title: `Peak advies: ${advies}`,
+              summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(1)} kWh. Aanbevolen oplossing: ${advies}.`,
+            }}
+          />
         </ScrollView>
       </SafeAreaView>
     </ImageBackground>

--- a/screens/ZakelijkAdviesScreen.js
+++ b/screens/ZakelijkAdviesScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import SaveAdviceButton from '../components/SaveAdviceButton';
 
 export default function ZakelijkAdviesScreen({ navigation, route }) {
   const { kwh1 = 0, kwh2 = 0, kwh3 = 0 } = route.params;
@@ -60,6 +61,14 @@ export default function ZakelijkAdviesScreen({ navigation, route }) {
           >
             <Text style={styles.buttonText}>Bekijk specificaties</Text>
           </TouchableOpacity>
+
+          <SaveAdviceButton
+            advice={{
+              id: `zakelijk-${specificatieScreen}`,
+              title: `Zakelijk advies: ${advies}`,
+              summary: `Benodigd vermogen: ${k0.toFixed(2)} kWh. Aanbevolen oplossing: ${advies}.`,
+            }}
+          />
         </ScrollView>
       </SafeAreaView>
     </ImageBackground>


### PR DESCRIPTION
## Summary
- add a reusable save button component that stores advice selections in AsyncStorage
- create an overview screen and navigation entry to review saved advices from the home page
- wire the save button into the various advice screens so results can be stored for later

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbf48dd9e4832ca7c6fba3edf5613c