### PR TITLE
Add interactive appointment scheduler to HomeScreen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.2",
+        "react-native-calendars": "^1.1313.0",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -6608,6 +6609,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -7234,6 +7241,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7857,6 +7874,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -8078,6 +8112,38 @@
         }
       }
     },
+    "node_modules/react-native-calendars": {
+      "version": "1.1313.0",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1313.0.tgz",
+      "integrity": "sha512-YQ7Vg57rBRVymolamYDTxZ0lPOELTDHQbTukTWdxR47aRBYJwKI6ocRbwcY5gYgyDwNgJS4uLGu5AvmYS74LYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-safe-area-context": "4.5.0",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
+    "node_modules/react-native-calendars/node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -8171,6 +8237,12 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
     },
     "node_modules/react-native-toast-message": {
       "version": "2.3.3",
@@ -8342,6 +8414,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/regenerate": {
@@ -9430,6 +9517,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -9931,6 +10024,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml2js": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.2",
+    "react-native-calendars": "^1.1313.0",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.4.0",

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,5 +1,5 @@
 // screens/HomeScreen.js
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
   View,
   Text,
@@ -8,12 +8,314 @@ import {
   Image,
   SafeAreaView,
   useWindowDimensions,
-  ImageBackground,
   Platform,
+  ScrollView,
+  TextInput,
+  Alert,
+  ActivityIndicator,
 } from 'react-native';
+import { Calendar, LocaleConfig } from 'react-native-calendars';
+import {
+  collection,
+  doc,
+  getDoc,
+  onSnapshot,
+  serverTimestamp,
+  setDoc,
+} from 'firebase/firestore';
+
+import { auth, db } from '../firebaseConfig';
+import {
+  isEmailConfigured,
+  sendAppointmentEmails,
+} from '../support/email';
+
+LocaleConfig.locales.nl = {
+  monthNames: [
+    'januari',
+    'februari',
+    'maart',
+    'april',
+    'mei',
+    'juni',
+    'juli',
+    'augustus',
+    'september',
+    'oktober',
+    'november',
+    'december',
+  ],
+  monthNamesShort: [
+    'jan',
+    'feb',
+    'mrt',
+    'apr',
+    'mei',
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'okt',
+    'nov',
+    'dec',
+  ],
+  dayNames: [
+    'zondag',
+    'maandag',
+    'dinsdag',
+    'woensdag',
+    'donderdag',
+    'vrijdag',
+    'zaterdag',
+  ],
+  dayNamesShort: ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
+  today: 'Vandaag',
+};
+LocaleConfig.defaultLocale = 'nl';
+
+const TIME_SLOTS = (() => {
+  const slots = [];
+  for (let hour = 9; hour <= 17; hour += 1) {
+    for (let minute = 0; minute < 60; minute += 30) {
+      if (hour === 17 && minute > 0) {
+        break;
+      }
+      slots.push(
+        `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+      );
+    }
+  }
+  return slots;
+})();
+
+const OFFICE_ADDRESS = 'Industrieweg 6, Stolwijk';
+
+function formatDateLabel(dateString) {
+  if (!dateString) {
+    return '';
+  }
+
+  try {
+    const formatter = new Intl.DateTimeFormat('nl-NL', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    return formatter.format(new Date(`${dateString}T12:00:00`));
+  } catch (error) {
+    return dateString;
+  }
+}
 
 export default function HomeScreen({ navigation }) {
   const { width } = useWindowDimensions();
+  const today = useMemo(() => new Date(), []);
+  const todayString = useMemo(() => today.toISOString().split('T')[0], [today]);
+  const [selectedDate, setSelectedDate] = useState('');
+  const [selectedTime, setSelectedTime] = useState('');
+  const [locationType, setLocationType] = useState('office');
+  const [customAddress, setCustomAddress] = useState('');
+  const [contactName, setContactName] = useState(auth.currentUser?.displayName || '');
+  const [bookedSlots, setBookedSlots] = useState({});
+  const [loadingSlots, setLoadingSlots] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const userEmail = auth.currentUser?.email || '';
+
+  useEffect(() => {
+    const appointmentsRef = collection(db, 'appointments');
+    const unsubscribe = onSnapshot(
+      appointmentsRef,
+      (snapshot) => {
+        const nextSlots = {};
+
+        snapshot.forEach((docSnap) => {
+          const data = docSnap.data();
+          if (!data?.date || !data?.time) {
+            return;
+          }
+
+          if (!nextSlots[data.date]) {
+            nextSlots[data.date] = new Set();
+          }
+          nextSlots[data.date].add(data.time);
+        });
+
+        const formatted = Object.fromEntries(
+          Object.entries(nextSlots).map(([date, value]) => [
+            date,
+            Array.from(value).sort(),
+          ])
+        );
+
+        setBookedSlots(formatted);
+        setLoadingSlots(false);
+      },
+      (error) => {
+        console.error('Fout bij het ophalen van afspraken', error);
+        setBookedSlots({});
+        setLoadingSlots(false);
+      }
+    );
+
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    setSelectedTime('');
+  }, [selectedDate]);
+
+  const availableTimes = useMemo(() => {
+    if (!selectedDate) {
+      return [];
+    }
+
+    const bookedForDay = bookedSlots[selectedDate] || [];
+    const now = new Date();
+
+    return TIME_SLOTS.filter((slot) => {
+      if (bookedForDay.includes(slot)) {
+        return false;
+      }
+
+      if (selectedDate === todayString) {
+        const [hour, minute] = slot.split(':').map(Number);
+        const slotDate = new Date();
+        slotDate.setHours(hour, minute, 0, 0);
+        if (slotDate <= now) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [bookedSlots, selectedDate, todayString]);
+
+  const markedDates = useMemo(() => {
+    const marks = {};
+
+    Object.entries(bookedSlots).forEach(([date, times]) => {
+      const fullyBooked = times.length >= TIME_SLOTS.length;
+      if (fullyBooked) {
+        marks[date] = {
+          disabled: true,
+          disableTouchEvent: true,
+          marked: true,
+          dotColor: '#d9534f',
+        };
+      } else {
+        marks[date] = {
+          ...(marks[date] || {}),
+          marked: true,
+          dotColor: '#1f6f34',
+        };
+      }
+    });
+
+    if (selectedDate) {
+      marks[selectedDate] = {
+        ...(marks[selectedDate] || {}),
+        selected: true,
+        selectedColor: '#f7941e',
+        selectedTextColor: '#fff',
+      };
+    }
+
+    return marks;
+  }, [bookedSlots, selectedDate]);
+
+  const locationLabel = locationType === 'home' ? 'Thuis' : 'Bij WattsNext';
+  const appointmentAddress =
+    locationType === 'home' && customAddress.trim()
+      ? customAddress.trim()
+      : OFFICE_ADDRESS;
+
+  const formattedDate = formatDateLabel(selectedDate);
+
+  const canSubmit =
+    Boolean(
+      selectedDate &&
+        selectedTime &&
+        contactName.trim() &&
+        userEmail &&
+        (locationType === 'office' || customAddress.trim())
+    ) && !submitting;
+
+  const handleSubmitAppointment = async () => {
+    if (!canSubmit) {
+      return;
+    }
+
+    const trimmedName = contactName.trim();
+    const trimmedAddress =
+      locationType === 'home' ? customAddress.trim() : OFFICE_ADDRESS;
+
+    if (locationType === 'home' && !trimmedAddress) {
+      Alert.alert('Adres ontbreekt', 'Voer een adres in voor de afspraak thuis.');
+      return;
+    }
+
+    const slotId = `${selectedDate}_${selectedTime.replace(':', '-')}`;
+    const appointmentRef = doc(db, 'appointments', slotId);
+
+    setSubmitting(true);
+
+    try {
+      const existing = await getDoc(appointmentRef);
+      if (existing.exists()) {
+        Alert.alert(
+          'Tijdslot niet beschikbaar',
+          'Dit tijdslot is zojuist geboekt. Kies een andere tijd.'
+        );
+        return;
+      }
+
+      await setDoc(appointmentRef, {
+        date: selectedDate,
+        time: selectedTime,
+        location: locationType,
+        address: trimmedAddress,
+        contactName: trimmedName,
+        contactEmail: userEmail,
+        createdAt: serverTimestamp(),
+      });
+
+      const emailResult = await sendAppointmentEmails({
+        clientEmail: userEmail,
+        clientName: trimmedName,
+        formattedDate,
+        time: selectedTime,
+        locationLabel,
+        address: trimmedAddress,
+      });
+
+      if (!emailResult.success) {
+        const message = isEmailConfigured()
+          ? 'De afspraak is ingepland, maar het versturen van de bevestigingsmail is mislukt.'
+          :
+            'De afspraak is ingepland. Configureer de EXPO_PUBLIC_EMAILJS_* variabelen om automatische e-mails te versturen.';
+        Alert.alert('Afspraak ingepland', message);
+      } else {
+        Alert.alert(
+          'Afspraak ingepland',
+          'Je ontvangt zo een bevestiging in de mail. WattsNext wordt ook op de hoogte gebracht.'
+        );
+      }
+
+      setSelectedDate('');
+      setSelectedTime('');
+      setCustomAddress('');
+      setLocationType('office');
+    } catch (error) {
+      console.error('Fout bij het plannen van een afspraak', error);
+      Alert.alert(
+        'Er ging iets mis',
+        'Het is niet gelukt om de afspraak te plannen. Probeer het later opnieuw.'
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <View style={styles.container}>
@@ -35,7 +337,14 @@ export default function HomeScreen({ navigation }) {
           <Text style={styles.backText}>← Terug naar log-in</Text>
         </TouchableOpacity>
 
-        <View style={styles.content}>
+        <ScrollView
+          contentContainerStyle={[
+            styles.scrollContent,
+            { paddingHorizontal: width > 768 ? 48 : 24 },
+          ]}
+          showsVerticalScrollIndicator={false}
+        >
+          <View style={styles.content}>
           <Image
             source={require('../assets/logo.png')}
             style={[
@@ -89,7 +398,199 @@ export default function HomeScreen({ navigation }) {
           >
             <Text style={[styles.secondaryButtonText, { fontSize: width > 768 ? 18 : 16 }]}>Opgeslagen adviezen</Text>
           </TouchableOpacity>
-        </View>
+          </View>
+
+          <View
+            style={[
+              styles.schedulerCard,
+              { width: width > 992 ? '70%' : '100%' },
+            ]}
+          >
+            <Text style={styles.schedulerTitle}>Plan direct een afspraak</Text>
+            <Text style={styles.schedulerSubtitle}>
+              Kies een datum, selecteer een tijd tussen 09:00 en 17:00 en geef aan of we
+              bij jou langskomen of dat je liever op kantoor afspreekt.
+            </Text>
+
+            {loadingSlots ? (
+              <View style={styles.loadingWrapper}>
+                <ActivityIndicator size="large" color="#f7941e" />
+                <Text style={styles.loadingText}>Beschikbaarheid laden…</Text>
+              </View>
+            ) : (
+              <>
+                <Calendar
+                  minDate={todayString}
+                  markedDates={markedDates}
+                  onDayPress={(day) => setSelectedDate(day.dateString)}
+                  enableSwipeMonths
+                  theme={{
+                    todayTextColor: '#f7941e',
+                    arrowColor: '#f7941e',
+                    textDayFontFamily: Platform.select({
+                      ios: 'System',
+                      android: 'Roboto',
+                      default: 'sans-serif',
+                    }),
+                    textMonthFontWeight: '600',
+                    textDayHeaderFontWeight: '600',
+                  }}
+                />
+
+                {selectedDate ? (
+                  <View style={styles.section}>
+                    <Text style={styles.sectionTitle}>Beschikbare tijden</Text>
+                    {availableTimes.length === 0 ? (
+                      <Text style={styles.emptyMessage}>
+                        Alle tijdsloten zijn bezet op deze dag. Kies een andere datum.
+                      </Text>
+                    ) : (
+                      <View style={styles.timeGrid}>
+                        {availableTimes.map((time) => {
+                          const isSelected = selectedTime === time;
+                          return (
+                            <TouchableOpacity
+                              key={time}
+                              style={[
+                                styles.timeSlot,
+                                isSelected && styles.timeSlotSelected,
+                              ]}
+                              onPress={() => setSelectedTime(time)}
+                              accessibilityRole="button"
+                              accessibilityLabel={`Kies tijdstip ${time}`}
+                            >
+                              <Text
+                                style={[
+                                  styles.timeSlotText,
+                                  isSelected && styles.timeSlotTextSelected,
+                                ]}
+                              >
+                                {time}
+                              </Text>
+                            </TouchableOpacity>
+                          );
+                        })}
+                      </View>
+                    )}
+                  </View>
+                ) : (
+                  <Text style={styles.emptyMessage}>
+                    Selecteer eerst een datum in de kalender om beschikbare tijden te zien.
+                  </Text>
+                )}
+
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>Voorkeurslocatie</Text>
+                  <View style={styles.locationRow}>
+                    <TouchableOpacity
+                      style={[
+                        styles.locationButton,
+                        locationType === 'office' && styles.locationButtonActive,
+                      ]}
+                      onPress={() => setLocationType('office')}
+                    >
+                      <Text
+                        style={[
+                          styles.locationButtonText,
+                          locationType === 'office' && styles.locationButtonTextActive,
+                        ]}
+                      >
+                        WattsNext kantoor
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[
+                        styles.locationButton,
+                        locationType === 'home' && styles.locationButtonActive,
+                      ]}
+                      onPress={() => setLocationType('home')}
+                    >
+                      <Text
+                        style={[
+                          styles.locationButtonText,
+                          locationType === 'home' && styles.locationButtonTextActive,
+                        ]}
+                      >
+                        Afspraak thuis
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                  <Text style={styles.locationInfo}>
+                    {locationType === 'home'
+                      ? 'Vul het adres in waar we mogen langskomen.'
+                      : `Het gesprek vindt plaats op ons kantoor: ${OFFICE_ADDRESS}.`}
+                  </Text>
+                  {locationType === 'home' && (
+                    <TextInput
+                      style={styles.input}
+                      placeholder="Straat, huisnummer, woonplaats"
+                      value={customAddress}
+                      onChangeText={setCustomAddress}
+                      placeholderTextColor="#666"
+                      accessibilityLabel="Adres voor afspraak"
+                    />
+                  )}
+                </View>
+
+                <View style={styles.section}>
+                  <Text style={styles.sectionTitle}>Contactgegevens</Text>
+                  <TextInput
+                    style={styles.input}
+                    placeholder="Naam"
+                    value={contactName}
+                    onChangeText={setContactName}
+                    placeholderTextColor="#666"
+                    accessibilityLabel="Naam contactpersoon"
+                  />
+                  <Text style={styles.readonlyInput}>E-mail: {userEmail || 'onbekend'}</Text>
+                  {!userEmail && (
+                    <Text style={styles.warningText}>
+                      We konden geen e-mailadres vinden. Log opnieuw in om een afspraak te kunnen plannen.
+                    </Text>
+                  )}
+                </View>
+
+                <View style={styles.summaryCard}>
+                  <Text style={styles.summaryTitle}>Overzicht afspraak</Text>
+                  <Text style={styles.summaryRow}>
+                    <Text style={styles.summaryLabel}>Datum:</Text>{' '}
+                    <Text style={styles.summaryValue}>
+                      {formattedDate || 'Nog niet gekozen'}
+                    </Text>
+                  </Text>
+                  <Text style={styles.summaryRow}>
+                    <Text style={styles.summaryLabel}>Tijd:</Text>{' '}
+                    <Text style={styles.summaryValue}>
+                      {selectedTime || 'Nog niet gekozen'}
+                    </Text>
+                  </Text>
+                  <Text style={styles.summaryRow}>
+                    <Text style={styles.summaryLabel}>Locatie:</Text>{' '}
+                    <Text style={styles.summaryValue}>{locationLabel}</Text>
+                  </Text>
+                  <Text style={styles.summaryRow}>
+                    <Text style={styles.summaryLabel}>Adres:</Text>{' '}
+                    <Text style={styles.summaryValue}>{appointmentAddress}</Text>
+                  </Text>
+                </View>
+
+                <TouchableOpacity
+                  style={[styles.submitButton, !canSubmit && styles.submitButtonDisabled]}
+                  onPress={handleSubmitAppointment}
+                  disabled={!canSubmit}
+                  accessibilityRole="button"
+                  accessibilityLabel="Bevestig afspraak"
+                >
+                  {submitting ? (
+                    <ActivityIndicator color="#fff" />
+                  ) : (
+                    <Text style={styles.submitButtonText}>Afspraak bevestigen</Text>
+                  )}
+                </TouchableOpacity>
+              </>
+            )}
+          </View>
+        </ScrollView>
       </SafeAreaView>
     </View>
   );
@@ -113,13 +614,17 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
+  scrollContent: {
+    paddingBottom: 48,
+    gap: 32,
     alignItems: 'center',
-    paddingHorizontal: 24,
+  },
+  content: {
+    width: '100%',
     maxWidth: 1200,
-    alignSelf: 'center',
+    alignItems: 'center',
+    gap: 16,
+    paddingTop: 32,
   },
   logo: {
     marginBottom: 40,
@@ -166,5 +671,156 @@ const styles = StyleSheet.create({
     color: '#1a73e8',
     fontSize: 16,
     fontWeight: '500',
+  },
+  schedulerCard: {
+    backgroundColor: '#ffffffee',
+    borderRadius: 18,
+    padding: 24,
+    width: '100%',
+    maxWidth: 900,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.1,
+    shadowRadius: 16,
+    elevation: 6,
+    gap: 20,
+  },
+  schedulerTitle: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#1f6f34',
+  },
+  schedulerSubtitle: {
+    fontSize: 15,
+    color: '#333',
+    lineHeight: 22,
+  },
+  loadingWrapper: {
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 20,
+  },
+  loadingText: {
+    color: '#333',
+  },
+  section: {
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#1f6f34',
+  },
+  emptyMessage: {
+    color: '#555',
+    fontStyle: 'italic',
+  },
+  timeGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  timeSlot: {
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#1f6f34',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    backgroundColor: '#fff',
+  },
+  timeSlotSelected: {
+    backgroundColor: '#1f6f34',
+  },
+  timeSlotText: {
+    color: '#1f6f34',
+    fontWeight: '600',
+  },
+  timeSlotTextSelected: {
+    color: '#fff',
+  },
+  locationRow: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  locationButton: {
+    flexGrow: 1,
+    borderWidth: 1,
+    borderColor: '#f7941e',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    backgroundColor: '#fff',
+  },
+  locationButtonActive: {
+    backgroundColor: '#f7941e',
+  },
+  locationButtonText: {
+    color: '#f7941e',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  locationButtonTextActive: {
+    color: '#fff',
+  },
+  locationInfo: {
+    color: '#555',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#c7c7c7',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: '#fff',
+    color: '#000',
+  },
+  readonlyInput: {
+    marginTop: 8,
+    color: '#555',
+  },
+  warningText: {
+    color: '#d9534f',
+    marginTop: 6,
+  },
+  summaryCard: {
+    backgroundColor: '#f7f9f8',
+    borderRadius: 12,
+    padding: 16,
+    gap: 8,
+    borderWidth: 1,
+    borderColor: '#dfe7e3',
+  },
+  summaryTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#1f6f34',
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    color: '#333',
+  },
+  summaryLabel: {
+    fontWeight: '600',
+    color: '#1f6f34',
+  },
+  summaryValue: {
+    color: '#333',
+  },
+  submitButton: {
+    backgroundColor: '#1f6f34',
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  submitButtonDisabled: {
+    backgroundColor: '#9fb7a6',
+  },
+  submitButtonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '700',
   },
 });

--- a/support/email.js
+++ b/support/email.js
@@ -1,0 +1,88 @@
+const EMAIL_ENDPOINT = 'https://api.emailjs.com/api/v1.0/email/send';
+
+const SERVICE_ID = process.env.EXPO_PUBLIC_EMAILJS_SERVICE_ID;
+const TEMPLATE_ID_CLIENT = process.env.EXPO_PUBLIC_EMAILJS_TEMPLATE_ID_CLIENT;
+const TEMPLATE_ID_TEAM = process.env.EXPO_PUBLIC_EMAILJS_TEMPLATE_ID_TEAM;
+const PUBLIC_KEY = process.env.EXPO_PUBLIC_EMAILJS_PUBLIC_KEY;
+const TEAM_EMAIL =
+  process.env.EXPO_PUBLIC_APPOINTMENT_TEAM_EMAIL || 'info@wattsnext.energy';
+
+export function isEmailConfigured() {
+  return Boolean(
+    SERVICE_ID && TEMPLATE_ID_CLIENT && TEMPLATE_ID_TEAM && PUBLIC_KEY
+  );
+}
+
+export async function sendAppointmentEmails({
+  clientEmail,
+  clientName,
+  formattedDate,
+  time,
+  locationLabel,
+  address,
+}) {
+  if (!isEmailConfigured()) {
+    console.warn(
+      'Email service niet geconfigureerd. Stel de EXPO_PUBLIC_EMAILJS_* variabelen in om e-mails te verzenden.'
+    );
+    return { success: false, reason: 'missing-configuration' };
+  }
+
+  const baseParams = {
+    klant_naam: clientName,
+    klant_email: clientEmail,
+    afspraak_datum: formattedDate,
+    afspraak_tijd: time,
+    afspraak_locatie: locationLabel,
+    afspraak_adres: address,
+  };
+
+  const payloads = [
+    {
+      service_id: SERVICE_ID,
+      template_id: TEMPLATE_ID_CLIENT,
+      user_id: PUBLIC_KEY,
+      template_params: {
+        ...baseParams,
+        to_email: clientEmail,
+      },
+    },
+    {
+      service_id: SERVICE_ID,
+      template_id: TEMPLATE_ID_TEAM,
+      user_id: PUBLIC_KEY,
+      template_params: {
+        ...baseParams,
+        to_email: TEAM_EMAIL,
+      },
+    },
+  ];
+
+  const results = [];
+
+  for (const payload of payloads) {
+    try {
+      const response = await fetch(EMAIL_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        results.push({ ok: false, error: errorText });
+      } else {
+        results.push({ ok: true });
+      }
+    } catch (error) {
+      results.push({ ok: false, error: error?.message || 'Onbekende fout' });
+    }
+  }
+
+  return {
+    success: results.every((result) => result.ok),
+    results,
+  };
+}


### PR DESCRIPTION
## Summary
- add a calendar-driven appointment planner to the home screen with time-slot and location selection
- store appointments in Firestore, prevent double-booking, and collect home address details when required
- add an EmailJS helper so both the client and WattsNext receive configurable confirmation emails

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6435c7794832cb1f773706b2307ef