### PR TITLE
Fix splash screen fallback and migrate SafeAreaView usage

### DIFF
--- a/App.js
+++ b/App.js
@@ -76,7 +76,9 @@ export default function App() {
 
     (async () => {
       try {
-        await SplashScreen.preventAutoHideAsync();
+        if (SplashScreen?.preventAutoHideAsync) {
+          await SplashScreen.preventAutoHideAsync();
+        }
         await Asset.loadAsync(imageAssets);
       } catch (error) {
         console.warn('Failed to preload image assets', error);
@@ -103,7 +105,9 @@ export default function App() {
 
   useEffect(() => {
     if (assetsLoaded && authChecked) {
-      SplashScreen.hideAsync();
+      if (SplashScreen?.hideAsync) {
+        SplashScreen.hideAsync();
+      }
     }
   }, [assetsLoaded, authChecked]);
 

--- a/screens/Advies10Hoog.js
+++ b/screens/Advies10Hoog.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies10Hoog({ navigation }) {
   return (

--- a/screens/Advies10Laag.js
+++ b/screens/Advies10Laag.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies10Laag({ navigation }) {
   return (

--- a/screens/Advies12_5Hoog.js
+++ b/screens/Advies12_5Hoog.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies12_5Hoog({ navigation }) {
   return (

--- a/screens/Advies15Hoog.js
+++ b/screens/Advies15Hoog.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies15Hoog({ navigation }) {
   return (

--- a/screens/Advies17_5Hoog.js
+++ b/screens/Advies17_5Hoog.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies17_5Hoog({ navigation }) {
   return (

--- a/screens/Advies20Hoog.js
+++ b/screens/Advies20Hoog.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies20Hoog({ navigation }) {
   return (

--- a/screens/Advies5kWhScreen.js
+++ b/screens/Advies5kWhScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies5kWhScreen({ navigation }) {
   return (

--- a/screens/Advies7_5Hoog.js
+++ b/screens/Advies7_5Hoog.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, Image, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function Advies7_5Hoog({ navigation }) {
   return (

--- a/screens/AdviesScreen.js
+++ b/screens/AdviesScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useRoute, useNavigation } from '@react-navigation/native';
-import { View, Text, ActivityIndicator, StyleSheet, ImageBackground, SafeAreaView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { View, Text, ActivityIndicator, StyleSheet, ImageBackground } from 'react-native';
 
 export default function AdviesScreen() {
   const route = useRoute();

--- a/screens/EnergieHandel.js
+++ b/screens/EnergieHandel.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function EnergieHandel({ navigation }) {

--- a/screens/EnergiehandelVraagScreen.js
+++ b/screens/EnergiehandelVraagScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function EnergiehandelVraagScreen({ navigation, route }) {

--- a/screens/Fase1Screen.js
+++ b/screens/Fase1Screen.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ImageBackground } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRoute } from '@react-navigation/native';
 
 export default function Fase1Screen({ navigation }) {

--- a/screens/Fase3ZekeringScreen.js
+++ b/screens/Fase3ZekeringScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ImageBackground } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRoute } from '@react-navigation/native';
 
 export default function Fase3ZekeringScreen({ navigation }) {

--- a/screens/HandelNoodstroomVraagScreen.js
+++ b/screens/HandelNoodstroomVraagScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function HandelNoodstroomVraagScreen({ navigation, route }) {

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -1,4 +1,5 @@
 // screens/HomeScreen.js
+import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useEffect, useMemo, useState } from "react";
 import {
   View,
@@ -6,13 +7,12 @@ import {
   StyleSheet,
   TouchableOpacity,
   Image,
-  SafeAreaView,
   useWindowDimensions,
   Platform,
   ScrollView,
   TextInput,
   Alert,
-  ActivityIndicator,
+  ActivityIndicator
 } from "react-native";
 
 import { auth, db } from "../firebaseConfig";

--- a/screens/LoadShifting.js
+++ b/screens/LoadShifting.js
@@ -1,4 +1,5 @@
 // screens/LoadShiftingVraagScreen.js
+import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useState } from 'react';
 import {
   View,
@@ -9,8 +10,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function LoadShifting({ navigation }) {

--- a/screens/LoadShiftingEnergiehandelVraagScreen.js
+++ b/screens/LoadShiftingEnergiehandelVraagScreen.js
@@ -1,4 +1,5 @@
 // screens/LoadShiftingEnergiehandelVraagScreen.js
+import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useState } from 'react';
 import {
   View,
@@ -9,8 +10,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function LoadShiftingEnergiehandelVraagScreen({ navigation, route }) {

--- a/screens/LoadShiftingNoodstroomVraagScreen.js
+++ b/screens/LoadShiftingNoodstroomVraagScreen.js
@@ -1,4 +1,5 @@
 // screens/LoadShiftingNoodstroomVraagScreen.js
+import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useState } from 'react';
 import {
   View,
@@ -9,8 +10,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function LoadShiftingNoodstroomVraagScreen({ navigation, route }) {

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -1,15 +1,15 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
   StyleSheet,
   TextInput,
   TouchableOpacity,
-  SafeAreaView,
   Image,
   KeyboardAvoidingView,
   Platform,
-  useWindowDimensions,
+  useWindowDimensions
 } from 'react-native';
 import { auth } from '../firebaseConfig';
 import { signInWithEmailAndPassword } from 'firebase/auth';

--- a/screens/Netcongestie.js
+++ b/screens/Netcongestie.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView
+  ImageBackground
 } from 'react-native';
 
 export default function Netcongestie({ navigation }) {

--- a/screens/NetcongestieEnergiehandelVraag.js
+++ b/screens/NetcongestieEnergiehandelVraag.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function NetcongestieEnergiehandelVraag({ navigation, route }) {

--- a/screens/NetcongestieNoodstroomVraag.js
+++ b/screens/NetcongestieNoodstroomVraag.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function NetcongestieNoodstroomVraag({ navigation, route }) {

--- a/screens/NoodstroomEnergiehandelVraagScreen.js
+++ b/screens/NoodstroomEnergiehandelVraagScreen.js
@@ -1,9 +1,16 @@
 // screens/NoodstroomEnergiehandelVraagScreen.js
+import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useState } from 'react';
 import {
-  View, Text, TextInput, TouchableOpacity,
-  StyleSheet, ScrollView, KeyboardAvoidingView, Platform,
-  ImageBackground, SafeAreaView
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  ImageBackground
 } from 'react-native';
 
 export default function NoodstroomEnergiehandelVraag({ navigation, route }) {

--- a/screens/NoodstroomGegevensScreen.js
+++ b/screens/NoodstroomGegevensScreen.js
@@ -1,8 +1,15 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  View, Text, TextInput, StyleSheet,
-  TouchableOpacity, KeyboardAvoidingView,
-  Platform, ScrollView, ImageBackground, SafeAreaView
+  View,
+  Text,
+  TextInput,
+  StyleSheet,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  ImageBackground
 } from 'react-native';
 
 export default function NoodstroomGegevensScreen({ navigation, route }) {

--- a/screens/NoodstroomVraagScreen.js
+++ b/screens/NoodstroomVraagScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 
 export default function NoodstroomVraagScreen({ navigation, route }) {

--- a/screens/Noodstroomvoorziening.js
+++ b/screens/Noodstroomvoorziening.js
@@ -1,8 +1,15 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
-  View, Text, TextInput, TouchableOpacity,
-  StyleSheet, ScrollView, KeyboardAvoidingView, Platform,
-  ImageBackground, SafeAreaView
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  ImageBackground
 } from 'react-native';
 
 export default function Noodstroomvoorziening({ navigation }) {

--- a/screens/OverzichtZakelijkAdviesScreen.js
+++ b/screens/OverzichtZakelijkAdviesScreen.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -6,10 +7,9 @@ import {
   TouchableOpacity,
   Image,
   ImageBackground,
-  SafeAreaView,
   ScrollView,
   Linking,
-  Alert,
+  Alert
 } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
 

--- a/screens/ParticulierScreen.js
+++ b/screens/ParticulierScreen.js
@@ -1,12 +1,12 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   ImageBackground,
-  SafeAreaView,
-  Platform,
+  Platform
 } from 'react-native';
 
 export default function ParticulierScreen({ navigation }) {

--- a/screens/PeakEnergieHandelVraagScreen.js
+++ b/screens/PeakEnergieHandelVraagScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView
+  ImageBackground
 } from 'react-native';
 
 export default function PeakEnergieHandelVraagScreen({ navigation, route }) {

--- a/screens/PeakNoodstroomVraagScreen.js
+++ b/screens/PeakNoodstroomVraagScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView
+  ImageBackground
 } from 'react-native';
 
 export default function PeakNoodstroomVraagScreen({ navigation, route }) {

--- a/screens/PeakShavingScreen.js
+++ b/screens/PeakShavingScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   ScrollView,
   KeyboardAvoidingView,
   Platform,
-  ImageBackground,
-  SafeAreaView
+  ImageBackground
 } from 'react-native';
 
 export default function PeakShavingScreen({ navigation }) {

--- a/screens/PersoonsgegevensScreen.js
+++ b/screens/PersoonsgegevensScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -7,8 +8,7 @@ import {
   TouchableOpacity,
   KeyboardAvoidingView,
   ScrollView,
-  ImageBackground,
-  SafeAreaView
+  ImageBackground
 } from 'react-native';
 import { useRoute } from '@react-navigation/native';
 

--- a/screens/RegisterScreen.js
+++ b/screens/RegisterScreen.js
@@ -1,4 +1,5 @@
 // screens/RegisterScreen.js
+import { SafeAreaView } from 'react-native-safe-area-context';
 import React, { useState } from 'react';
 import {
   View,
@@ -7,14 +8,13 @@ import {
   TouchableOpacity,
   StyleSheet,
   Image,
-  SafeAreaView,
   useWindowDimensions,
   Platform,
   KeyboardAvoidingView,
   ScrollView,
   TouchableWithoutFeedback,
   Keyboard,
-  ActivityIndicator,
+  ActivityIndicator
 } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { createUserWithEmailAndPassword } from 'firebase/auth';

--- a/screens/SavedAdvicesScreen.js
+++ b/screens/SavedAdvicesScreen.js
@@ -1,15 +1,15 @@
 import React, { useCallback, useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   ActivityIndicator,
   Alert,
   FlatList,
   ImageBackground,
   Linking,
-  SafeAreaView,
   StyleSheet,
   Text,
   TouchableOpacity,
-  View,
+  View
 } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/native';

--- a/screens/Step1Screen.js
+++ b/screens/Step1Screen.js
@@ -1,12 +1,12 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
-  SafeAreaView,
   Image,
-  Platform,
+  Platform
 } from 'react-native';
 
 export default function Step2Screen({ navigation }) {

--- a/screens/ZakelijkAdviesHandelScreen.js
+++ b/screens/ZakelijkAdviesHandelScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ZakelijkAdviesHandelScreen({ route, navigation }) {
   const { kwh1, kwh2 = 0 } = route.params;

--- a/screens/ZakelijkAdviesLoadShiftingScreen.js
+++ b/screens/ZakelijkAdviesLoadShiftingScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ZakelijkAdviesLoadShiftingScreen({ route, navigation }) {
   const { kwh1 = 0, kwh2 = 0, kwh3 = 0 } = route.params;

--- a/screens/ZakelijkAdviesNetcongestie.js
+++ b/screens/ZakelijkAdviesNetcongestie.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -6,8 +7,7 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
 

--- a/screens/ZakelijkAdviesNoodstroom.js
+++ b/screens/ZakelijkAdviesNoodstroom.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -6,8 +7,7 @@ import {
   Image,
   TouchableOpacity,
   ScrollView,
-  ImageBackground,
-  SafeAreaView,
+  ImageBackground
 } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
 

--- a/screens/ZakelijkAdviesPeakScreen.js
+++ b/screens/ZakelijkAdviesPeakScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Image, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Image, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
   const { kwh1, kwh2 = 0, kwh3 = 0 } = route.params;

--- a/screens/ZakelijkAdviesScreen.js
+++ b/screens/ZakelijkAdviesScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, ImageBackground, SafeAreaView } from 'react-native';
+import { View, Text, Image, StyleSheet, ScrollView, TouchableOpacity, ImageBackground } from 'react-native';
 import SaveAdviceButton from '../components/SaveAdviceButton';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ZakelijkAdviesScreen({ navigation, route }) {
   const { kwh1 = 0, kwh2 = 0, kwh3 = 0 } = route.params;

--- a/screens/ZakelijkDoelScreen.js
+++ b/screens/ZakelijkDoelScreen.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ImageBackground, SafeAreaView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, ImageBackground } from 'react-native';
 
 export default function ZakelijkDoelScreen({ navigation }) {
   const opties = [

--- a/screens/ZakelijkNoodstroomScreen.js
+++ b/screens/ZakelijkNoodstroomScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -8,8 +9,7 @@ import {
   Alert,
   KeyboardAvoidingView,
   ScrollView,
-  ImageBackground,
-  SafeAreaView
+  ImageBackground
 } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 

--- a/screens/ZakelijkOpslagScreen.js
+++ b/screens/ZakelijkOpslagScreen.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -7,8 +8,7 @@ import {
   StyleSheet,
   KeyboardAvoidingView,
   ScrollView,
-  ImageBackground,
-  SafeAreaView
+  ImageBackground
 } from 'react-native';
 
 export default function ZakelijkOpslagScreen({ navigation }) {


### PR DESCRIPTION
## Summary
- guard Expo splash screen calls so the app no longer crashes when the module is unavailable (e.g. on web)
- migrate every screen to use SafeAreaView from react-native-safe-area-context to resolve the deprecation warning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb666565e0832c940cbd25b5b4311a