### PR TITLE
Apply Step1 background layout across screens

### DIFF
--- a/screens/AccountBeherenScreen.js
+++ b/screens/AccountBeherenScreen.js
@@ -1,5 +1,6 @@
 // screens/AccountBeherenScreen.js
 import React, { useState } from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   View,
   Text,
@@ -14,6 +15,7 @@ import {
 } from 'react-native';
 import { deleteUser, reauthenticateWithCredential, EmailAuthProvider } from 'firebase/auth';
 import { auth } from '../firebaseConfig';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function AccountBeherenScreen({ navigation }) {
   const [loading, setLoading] = useState(false);
@@ -83,51 +85,75 @@ export default function AccountBeherenScreen({ navigation }) {
   };
 
   return (
-    <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
-      <ScrollView contentContainerStyle={styles.scrollContainer} keyboardShouldPersistTaps="handled">
-        <View style={styles.container}>
-          <Text style={styles.title}>Account beheren</Text>
-          <Text style={styles.body}>
-            Hier kun je je account permanent verwijderen. Dit is onomkeerbaar en verwijdert je gegevens.
-          </Text>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView
+            contentContainerStyle={styles.scrollContainer}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.content}>
+              <Text style={styles.title}>Account beheren</Text>
+              <Text style={styles.body}>
+                Hier kun je je account permanent verwijderen. Dit is onomkeerbaar en verwijdert je gegevens.
+              </Text>
 
-          <TouchableOpacity style={styles.deleteBtn} onPress={handleDeletePress} disabled={loading}>
-            {loading ? <ActivityIndicator /> : <Text style={styles.deleteText}>Verwijder mijn account</Text>}
-          </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.deleteBtn}
+                onPress={handleDeletePress}
+                disabled={loading}
+              >
+                {loading ? (
+                  <ActivityIndicator />
+                ) : (
+                  <Text style={styles.deleteText}>Verwijder mijn account</Text>
+                )}
+              </TouchableOpacity>
 
-          <View style={{ height: 24 }} />
+              <View style={{ height: 24 }} />
 
-          <Text style={styles.subTitle}>Problemen met verwijderen?</Text>
-          <Text style={styles.body}>
-            Soms is een recente aanmelding nodig. Log dan opnieuw in, of voer hieronder je wachtwoord in als je met
-            e-mail en wachtwoord bent ingelogd.
-          </Text>
+              <Text style={styles.subTitle}>Problemen met verwijderen?</Text>
+              <Text style={styles.body}>
+                Soms is een recente aanmelding nodig. Log dan opnieuw in, of voer hieronder je wachtwoord in als je met
+                e-mail en wachtwoord bent ingelogd.
+              </Text>
 
-          <TextInput
-            placeholder="Wachtwoord (alleen voor e-mail/password accounts)"
-            secureTextEntry
-            value={password}
-            onChangeText={setPassword}
-            style={styles.input}
-            autoCapitalize="none"
-          />
-          <TouchableOpacity style={styles.outlineBtn} onPress={handleReauthenticate} disabled={loading}>
-            <Text style={styles.outlineText}>Opnieuw verifiëren</Text>
-          </TouchableOpacity>
+              <TextInput
+                placeholder="Wachtwoord (alleen voor e-mail/password accounts)"
+                secureTextEntry
+                value={password}
+                onChangeText={setPassword}
+                style={styles.input}
+                autoCapitalize="none"
+              />
+              <TouchableOpacity
+                style={styles.outlineBtn}
+                onPress={handleReauthenticate}
+                disabled={loading}
+              >
+                <Text style={styles.outlineText}>Opnieuw verifiëren</Text>
+              </TouchableOpacity>
 
-          <View style={{ height: 16 }} />
-          <TouchableOpacity style={styles.linkBtn} onPress={() => navigation.goBack()}>
-            <Text style={styles.linkText}>← Terug</Text>
-          </TouchableOpacity>
-        </View>
-      </ScrollView>
+              <View style={{ height: 16 }} />
+              <TouchableOpacity style={styles.linkBtn} onPress={() => navigation.goBack()}>
+                <Text style={styles.linkText}>← Terug</Text>
+              </TouchableOpacity>
+            </View>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
     </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
   scrollContainer: { flexGrow: 1, justifyContent: 'center' },
-  container: { flex: 1, padding: 20, alignItems: 'center', justifyContent: 'center' },
+  content: { flex: 1, padding: 20, alignItems: 'center', justifyContent: 'center' },
   title: { fontSize: 24, fontWeight: '700', marginBottom: 8, color: '#3eaf4f', textAlign: 'center' },
   subTitle: { fontSize: 18, fontWeight: '700', marginTop: 8, marginBottom: 4 },
   body: { fontSize: 15, textAlign: 'center', maxWidth: 500, opacity: 0.9 },

--- a/screens/Advies10Hoog.js
+++ b/screens/Advies10Hoog.js
@@ -6,9 +6,10 @@ import ScreenBackground from "../components/ScreenBackground";
 
 export default function Advies10Hoog({ navigation }) {
   return (
-    <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
           <Text style={styles.text}>
             Op basis van uw gegevens adviseert WattsNext:
@@ -39,12 +40,17 @@ export default function Advies10Hoog({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     justifyContent: "center",
@@ -56,7 +62,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/Advies10Laag.js
+++ b/screens/Advies10Laag.js
@@ -6,9 +6,10 @@ import ScreenBackground from "../components/ScreenBackground";
 
 export default function Advies10Laag({ navigation }) {
   return (
-    <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
           <Text style={styles.text}>
             Op basis van uw gegevens adviseert WattsNext:
@@ -39,12 +40,17 @@ export default function Advies10Laag({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     justifyContent: "center",
@@ -56,7 +62,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/Advies12_5Hoog.js
+++ b/screens/Advies12_5Hoog.js
@@ -6,12 +6,13 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Advies12_5Hoog({ navigation }) {
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
           <Text style={styles.text}>
             Op basis van uw gegevens adviseert WattsNext:
@@ -41,12 +42,17 @@ export default function Advies12_5Hoog({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -60,7 +66,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/Advies15Hoog.js
+++ b/screens/Advies15Hoog.js
@@ -6,12 +6,13 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Advies15Hoog({ navigation }) {
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
           <Text style={styles.text}>
             Op basis van uw gegevens adviseert WattsNext:
@@ -41,12 +42,17 @@ export default function Advies15Hoog({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -60,7 +66,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/Advies17_5Hoog.js
+++ b/screens/Advies17_5Hoog.js
@@ -6,12 +6,13 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Advies17_5Hoog({ navigation }) {
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
           <Text style={styles.text}>
             Op basis van uw gegevens adviseert WattsNext:
@@ -41,12 +42,17 @@ export default function Advies17_5Hoog({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -60,7 +66,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/Advies20Hoog.js
+++ b/screens/Advies20Hoog.js
@@ -6,12 +6,13 @@ import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Advies20Hoog({ navigation }) {
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
           <Text style={styles.text}>
             Op basis van uw gegevens adviseert WattsNext:
@@ -41,12 +42,17 @@ export default function Advies20Hoog({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -60,7 +66,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/Advies5kWhScreen.js
+++ b/screens/Advies5kWhScreen.js
@@ -6,9 +6,10 @@ import ScreenBackground from "../components/ScreenBackground";
 
 export default function Advies5kWhScreen({ navigation }) {
   return (
-    <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
 
           <Text style={styles.text}>
@@ -37,12 +38,17 @@ export default function Advies5kWhScreen({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     justifyContent: "center",
@@ -54,7 +60,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/Advies7_5Hoog.js
+++ b/screens/Advies7_5Hoog.js
@@ -6,9 +6,10 @@ import ScreenBackground from "../components/ScreenBackground";
 
 export default function Advies7_5Hoog({ navigation }) {
   return (
-    <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
           <Text style={styles.title}>Persoonlijk Advies</Text>
           <Text style={styles.text}>
             Op basis van uw gegevens adviseert WattsNext:
@@ -39,12 +40,17 @@ export default function Advies7_5Hoog({ navigation }) {
             }}
           />
         </View>
-      </SafeAreaView>
-    </ScreenBackground>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     justifyContent: "center",
@@ -56,7 +62,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/AdviesScreen.js
+++ b/screens/AdviesScreen.js
@@ -59,21 +59,27 @@ export default function AdviesScreen() {
   }, []);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
-          <ActivityIndicator size="large" color="#f7941e" />
-          <Text style={styles.text}>Advies wordt berekend...</Text>
-        </View>
-      </SafeAreaView>
-    </ScreenBackground>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
+            <ActivityIndicator size="large" color="#f7941e" />
+            <Text style={styles.text}>Advies wordt berekend...</Text>
+          </View>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -87,7 +93,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",

--- a/screens/AgendaScreen.js
+++ b/screens/AgendaScreen.js
@@ -458,6 +458,7 @@ export default function AgendaScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    position: "relative",
     backgroundColor: "#f0f4f8",
   },
   backgroundWrapper: {

--- a/screens/EnergieHandel.js
+++ b/screens/EnergieHandel.js
@@ -38,17 +38,18 @@ export default function EnergieHandel({ navigation }) {
   };
 
   return (
-    <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>Handel op de energiemarkt</Text>
 
             <Text style={styles.label}>Gecontracteerd vermogen (kW)</Text>
@@ -100,14 +101,19 @@ export default function EnergieHandel({ navigation }) {
             <TouchableOpacity style={styles.button} onPress={handleNext}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     justifyContent: "center",
@@ -119,7 +125,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/EnergiehandelVraagScreen.js
+++ b/screens/EnergiehandelVraagScreen.js
@@ -44,20 +44,21 @@ export default function EnergiehandelVraagScreen({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u handelen op de energiemarkt?
             </Text>
@@ -124,14 +125,19 @@ export default function EnergiehandelVraagScreen({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -145,7 +151,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/Fase1Screen.js
+++ b/screens/Fase1Screen.js
@@ -9,15 +9,16 @@ export default function Fase1Screen({ navigation }) {
   const aansluiting = route.params?.aansluiting || "1-fase"; // fallback voor zekerheid
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
-          <Text style={styles.title}>
-            Welke zekering heeft je 1-fase aansluiting?
-          </Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
+            <Text style={styles.title}>
+              Welke zekering heeft je 1-fase aansluiting?
+            </Text>
 
           {/* 16A verwijst naar vast 5 kWh advies → geen aansluiting nodig */}
           <TouchableOpacity
@@ -45,13 +46,18 @@ export default function Fase1Screen({ navigation }) {
           >
             <Text style={styles.buttonText}>35A</Text>
           </TouchableOpacity>
-        </View>
-      </SafeAreaView>
-    </ScreenBackground>
+          </View>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -65,7 +71,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     justifyContent: "center",
     alignItems: "center",

--- a/screens/Fase3ZekeringScreen.js
+++ b/screens/Fase3ZekeringScreen.js
@@ -9,15 +9,16 @@ export default function Fase3ZekeringScreen({ navigation }) {
   const aansluiting = route.params?.aansluiting || "3-fase";
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
-          <Text style={styles.title}>
-            Welke zekering heeft je 3-fase aansluiting?
-          </Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
+            <Text style={styles.title}>
+              Welke zekering heeft je 3-fase aansluiting?
+            </Text>
 
           <TouchableOpacity
             style={styles.button}
@@ -45,13 +46,18 @@ export default function Fase3ZekeringScreen({ navigation }) {
           >
             <Text style={styles.buttonText}>35A</Text>
           </TouchableOpacity>
-        </View>
-      </SafeAreaView>
-    </ScreenBackground>
+          </View>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -65,7 +71,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  content: {
     flex: 1,
     justifyContent: "center",
     alignItems: "center",

--- a/screens/HandelNoodstroomVraagScreen.js
+++ b/screens/HandelNoodstroomVraagScreen.js
@@ -29,20 +29,21 @@ export default function HandelNoodstroomVraagScreen({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>Noodstroomvoorziening</Text>
 
             <Text style={styles.label}>Benodigde capaciteit (kWh)</Text>
@@ -68,14 +69,19 @@ export default function HandelNoodstroomVraagScreen({ navigation, route }) {
             <TouchableOpacity style={styles.button} onPress={handleNext}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -89,7 +95,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -8,9 +8,9 @@ import {
   Image,
   useWindowDimensions,
   ScrollView,
-  SafeAreaView,
   Platform,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { getAuth } from "firebase/auth";
 import ScreenBackground from "../components/ScreenBackground";
@@ -22,7 +22,7 @@ export default function HomeScreen({ navigation }) {
   const isWide = width > 768; // iPad / web / brede layout
 
   return (
-    <View style={styles.root}>
+    <View style={styles.container}>
       {/* Volledige achtergrond laag */}
       <ScreenBackground
         style={styles.backgroundImage}
@@ -142,8 +142,9 @@ export default function HomeScreen({ navigation }) {
 }
 
 const styles = StyleSheet.create({
-  root: {
+  container: {
     flex: 1,
+    position: "relative",
     backgroundColor: "#f0f4f8",
   },
 

--- a/screens/LoadShifting.js
+++ b/screens/LoadShifting.js
@@ -31,20 +31,21 @@ export default function LoadShifting({ navigation }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Energie-inkoop optimaliseren (Load Shifting)
             </Text>
@@ -72,14 +73,19 @@ export default function LoadShifting({ navigation }) {
             <TouchableOpacity style={styles.button} onPress={handleNext}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -93,7 +99,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/LoadShiftingEnergiehandelVraagScreen.js
+++ b/screens/LoadShiftingEnergiehandelVraagScreen.js
@@ -61,20 +61,21 @@ export default function LoadShiftingEnergiehandelVraagScreen({
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u handelen op de energiemarkt?
             </Text>
@@ -131,14 +132,19 @@ export default function LoadShiftingEnergiehandelVraagScreen({
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -152,7 +158,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/LoadShiftingNoodstroomVraagScreen.js
+++ b/screens/LoadShiftingNoodstroomVraagScreen.js
@@ -39,20 +39,21 @@ export default function LoadShiftingNoodstroomVraagScreen({
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u ruimte reserveren voor noodstroomvoorziening?
             </Text>
@@ -105,14 +106,19 @@ export default function LoadShiftingNoodstroomVraagScreen({
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -126,7 +132,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -36,16 +36,17 @@ export default function LoginScreen({ navigation }) {
   };
 
   return (
-    <KeyboardAvoidingView
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-      style={styles.container}
-    >
+    <View style={styles.container}>
       <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
-          <View style={styles.content}>
-            <Image
-              source={require("../assets/logo.png")}
-              style={{
+          <KeyboardAvoidingView
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            style={styles.keyboardAvoider}
+          >
+            <View style={styles.content}>
+              <Image
+                source={require("../assets/logo.png")}
+                style={{
                 width: width > 768 ? 300 : 200,
                 height: width > 768 ? 120 : 80,
                 marginBottom: 40,
@@ -90,10 +91,11 @@ export default function LoginScreen({ navigation }) {
             <TouchableOpacity style={styles.guestButton} onPress={handleGuest}>
               <Text style={styles.guestButtonText}>Doorgaan als gast</Text>
             </TouchableOpacity>
-          </View>
+            </View>
+          </KeyboardAvoidingView>
         </SafeAreaView>
       </ScreenBackground>
-    </KeyboardAvoidingView>
+    </View>
   );
 }
 
@@ -103,6 +105,9 @@ const styles = StyleSheet.create({
     position: "relative",
   },
   safeArea: {
+    flex: 1,
+  },
+  keyboardAvoider: {
     flex: 1,
   },
   content: {

--- a/screens/Netcongestie.js
+++ b/screens/Netcongestie.js
@@ -50,20 +50,21 @@ export default function Netcongestie({ navigation }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>Netcongestie Berekening</Text>
 
             <Text style={styles.info}></Text>
@@ -101,14 +102,19 @@ export default function Netcongestie({ navigation }) {
             <TouchableOpacity style={styles.button} onPress={handleNext}>
               <Text style={styles.buttonText}>Bereken en ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -122,8 +128,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/NetcongestieEnergiehandelVraag.js
+++ b/screens/NetcongestieEnergiehandelVraag.js
@@ -48,20 +48,21 @@ export default function NetcongestieEnergiehandelVraag({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u handelen op de energiemarkt?
             </Text>
@@ -128,14 +129,19 @@ export default function NetcongestieEnergiehandelVraag({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -149,7 +155,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/NetcongestieNoodstroomVraag.js
+++ b/screens/NetcongestieNoodstroomVraag.js
@@ -36,20 +36,21 @@ export default function NetcongestieNoodstroomVraag({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u ruimte reserveren voor noodstroomvoorziening?
             </Text>
@@ -102,14 +103,19 @@ export default function NetcongestieNoodstroomVraag({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -123,7 +129,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/NoodstroomEnergiehandelVraagScreen.js
+++ b/screens/NoodstroomEnergiehandelVraagScreen.js
@@ -45,20 +45,21 @@ export default function NoodstroomEnergiehandelVraag({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u handelen op de energiemarkt?
             </Text>
@@ -125,14 +126,19 @@ export default function NoodstroomEnergiehandelVraag({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -146,7 +152,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/NoodstroomGegevensScreen.js
+++ b/screens/NoodstroomGegevensScreen.js
@@ -28,20 +28,21 @@ export default function NoodstroomGegevensScreen({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>Noodstroomvoorziening</Text>
 
             <Text style={styles.label}>Benodigde capaciteit (kWh)</Text>
@@ -67,14 +68,19 @@ export default function NoodstroomGegevensScreen({ navigation, route }) {
             <TouchableOpacity style={styles.button} onPress={doorgaan}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -88,7 +94,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     justifyContent: "center",
     padding: 20,

--- a/screens/NoodstroomVraagScreen.js
+++ b/screens/NoodstroomVraagScreen.js
@@ -35,20 +35,21 @@ export default function NoodstroomVraagScreen({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u ruimte overhouden voor noodstroom?
             </Text>
@@ -101,14 +102,19 @@ export default function NoodstroomVraagScreen({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -122,7 +128,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/Noodstroomvoorziening.js
+++ b/screens/Noodstroomvoorziening.js
@@ -28,20 +28,21 @@ export default function Noodstroomvoorziening({ navigation }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>Noodstroomvoorziening</Text>
 
             <Text style={styles.label}>Benodigde capaciteit (kWh)</Text>
@@ -67,14 +68,19 @@ export default function Noodstroomvoorziening({ navigation }) {
             <TouchableOpacity style={styles.button} onPress={handleNext}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -88,7 +94,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/OffertesScreen.js
+++ b/screens/OffertesScreen.js
@@ -1,14 +1,7 @@
 // screens/OffertesScreen.js
 import React, { useEffect, useState } from "react";
-import {
-  SafeAreaView,
-  ScrollView,
-  View,
-  Text,
-  TouchableOpacity,
-  StyleSheet,
-  Platform,
-} from "react-native";
+import { ScrollView, View, Text, TouchableOpacity, StyleSheet, Platform } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { auth, db } from "../firebaseConfig";
 import {
@@ -74,15 +67,16 @@ export default function OffertesScreen({ navigation }) {
     Array.isArray(items) ? items.reduce((acc, it) => acc + (Number(it?.qty) || 1), 0) : 0;
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.container}>
       <ScreenBackground
         style={styles.backgroundImage}
         imageStyle={styles.backgroundImageInner}
       >
-        <ScrollView
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={false}
-        >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
           <Text style={styles.title}>Mijn offerte-aanvragen</Text>
 
           <TouchableOpacity
@@ -176,13 +170,15 @@ export default function OffertesScreen({ navigation }) {
               );
             })}
           </View>
-        </ScrollView>
+          </ScrollView>
+        </SafeAreaView>
       </ScreenBackground>
-    </SafeAreaView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: { flex: 1, position: "relative" },
   safeArea: { flex: 1, backgroundColor: "#f0f4f8" },
   backgroundImage: { flex: 1, width: "100%", height: "100%" },
   backgroundImageInner: {

--- a/screens/OverzichtZakelijkAdviesScreen.js
+++ b/screens/OverzichtZakelijkAdviesScreen.js
@@ -118,13 +118,14 @@ export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
   }, [mailtoLink]);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>Zakelijk Advies</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <Text style={styles.title}>Zakelijk Advies</Text>
           <Text style={styles.subtext}>
             Benodigd totaal: {kwhTotaal.toFixed(1)} kWh
           </Text>
@@ -185,13 +186,18 @@ export default function OverzichtZakelijkAdviesScreen({ route, navigation }) {
           >
             <Text style={styles.buttonText}>Terug naar begin</Text>
           </TouchableOpacity>
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -205,7 +211,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",

--- a/screens/ParticulierScreen.js
+++ b/screens/ParticulierScreen.js
@@ -55,6 +55,7 @@ export default function ParticulierScreen({ navigation }) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    position: "relative",
   },
   backgroundImage: {
     flex: 1,

--- a/screens/PeakEnergieHandelVraagScreen.js
+++ b/screens/PeakEnergieHandelVraagScreen.js
@@ -46,20 +46,21 @@ export default function PeakEnergieHandelVraagScreen({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView
-            contentContainerStyle={styles.container}
-            keyboardShouldPersistTaps="handled"
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
           >
+            <ScrollView
+              contentContainerStyle={styles.scrollContent}
+              keyboardShouldPersistTaps="handled"
+            >
             <Text style={styles.title}>
               Wilt u handelen op de energiemarkt?
             </Text>
@@ -126,14 +127,19 @@ export default function PeakEnergieHandelVraagScreen({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -147,7 +153,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     backgroundColor: "transparent",
     padding: 24,

--- a/screens/PeakNoodstroomVraagScreen.js
+++ b/screens/PeakNoodstroomVraagScreen.js
@@ -35,17 +35,18 @@ export default function PeakNoodstroomVraagScreen({ navigation, route }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView contentContainerStyle={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
+          >
+            <ScrollView contentContainerStyle={styles.scrollContent}>
             <Text style={styles.title}>
               Wilt u ruimte overhouden voor noodstroom?
             </Text>
@@ -80,14 +81,19 @@ export default function PeakNoodstroomVraagScreen({ navigation, route }) {
             >
               <Text style={styles.buttonText}>Nee, ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -101,7 +107,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/PeakShavingScreen.js
+++ b/screens/PeakShavingScreen.js
@@ -61,17 +61,18 @@ export default function PeakShavingScreen({ navigation }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView
-          style={{ flex: 1 }}
-          behavior={Platform.OS === "ios" ? "padding" : "height"}
-          keyboardVerticalOffset={80}
-        >
-          <ScrollView contentContainerStyle={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={80}
+          >
+            <ScrollView contentContainerStyle={styles.scrollContent}>
             <Text style={styles.title}>Peak Shaving</Text>
 
             <View style={styles.toggleContainer}>
@@ -144,14 +145,19 @@ export default function PeakShavingScreen({ navigation }) {
             <TouchableOpacity style={styles.button} onPress={handleNext}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -165,7 +171,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/PersoonsgegevensScreen.js
+++ b/screens/PersoonsgegevensScreen.js
@@ -30,14 +30,15 @@ export default function PersoonsgegevensScreen({ navigation }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
-          <ScrollView contentContainerStyle={styles.container}>
-            <Text style={styles.title}>Vul je gegevens in</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
+            <ScrollView contentContainerStyle={styles.scrollContent}>
+              <Text style={styles.title}>Vul je gegevens in</Text>
 
             <Text style={styles.label}>Jaarlijks stroomverbruik (kWh)</Text>
             <TextInput
@@ -72,14 +73,19 @@ export default function PersoonsgegevensScreen({ navigation }) {
             <TouchableOpacity style={styles.button} onPress={doorgaan}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -93,7 +99,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",

--- a/screens/ProductenScreen.js
+++ b/screens/ProductenScreen.js
@@ -4,7 +4,6 @@ import {
   useWindowDimensions,
   Alert,
   Platform,
-  SafeAreaView,
   ScrollView,
   View,
   Text,
@@ -13,6 +12,7 @@ import {
   TextInput,
   KeyboardAvoidingView,
 } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 import { sendProductQuoteEmail } from "../support/email";
 import { db, auth } from "../firebaseConfig";
@@ -415,23 +415,24 @@ const handleQuoteRequest = async (product) => {
   const selectedCount = selected.size;
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.container}>
       <ScreenBackground
         style={styles.backgroundImage}
         imageStyle={styles.backgroundImageInner}
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : undefined}
-          style={{ flex: 1 }}
-        >
-          <ScrollView
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={[
-              styles.scrollContent,
-              { paddingHorizontal: width > 768 ? 48 : 24 },
-            ]}
-            showsVerticalScrollIndicator={false}
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === "ios" ? "padding" : undefined}
+            style={{ flex: 1 }}
           >
+            <ScrollView
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={[
+                styles.scrollContent,
+                { paddingHorizontal: width > 768 ? 48 : 24 },
+              ]}
+              showsVerticalScrollIndicator={false}
+            >
             <Text style={[styles.title, { fontSize: width > 768 ? 32 : 24 }]}>
               Producten voor installateurs
             </Text>
@@ -589,14 +590,16 @@ const handleQuoteRequest = async (product) => {
                 );
               })}
             </View>
-          </ScrollView>
-        </KeyboardAvoidingView>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
       </ScreenBackground>
-    </SafeAreaView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: { flex: 1, position: "relative" },
   safeArea: { flex: 1, backgroundColor: "#f0f4f8" },
   backgroundImage: { flex: 1, width: "100%", height: "100%" },
   backgroundImageInner: {

--- a/screens/SavedAdvicesScreen.js
+++ b/screens/SavedAdvicesScreen.js
@@ -206,14 +206,15 @@ export default function SavedAdvicesScreen() {
   );
 
   return (
-    <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <View style={styles.container}>
-          <Text style={styles.title}>Opgeslagen adviezen</Text>
-          <Text style={styles.subtitle}>
-            Bewaar adviezen via de knoppen op de adviesschermen en bekijk ze
-            hier terug.
-          </Text>
+    <View style={styles.container}>
+      <ScreenBackground style={styles.background} imageStyle={styles.imageStyle}>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
+            <Text style={styles.title}>Opgeslagen adviezen</Text>
+            <Text style={styles.subtitle}>
+              Bewaar adviezen via de knoppen op de adviesschermen en bekijk ze
+              hier terug.
+            </Text>
 
           <TouchableOpacity
             style={styles.emailButton}
@@ -248,13 +249,21 @@ export default function SavedAdvicesScreen() {
               contentContainerStyle={styles.listContent}
             />
           )}
-        </View>
-      </SafeAreaView>
-    </ScreenBackground>
+          </View>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
+  safeArea: {
+    flex: 1,
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -268,7 +277,7 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: { flex: 1, padding: 24 },
+  content: { flex: 1, padding: 24 },
   title: {
     fontSize: 24,
     fontWeight: "bold",

--- a/screens/Spec_HV_particulier.js
+++ b/screens/Spec_HV_particulier.js
@@ -1,27 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Spec_HV_particulier() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties Hoog voltage</Text>
-      <Image
-        source={require('../assets/spec-HV-particulier.png')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties Hoog voltage</Text>
+            <Image
+              source={require('../assets/spec-HV-particulier.png')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/Spec_LV_particulier.js
+++ b/screens/Spec_LV_particulier.js
@@ -1,26 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Spec_LV_particulier() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties laag voltage</Text>
-      <Image
-        source={require('../assets/spec-LV-particulier.jpg')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties laag voltage</Text>
+            <Image
+              source={require('../assets/spec-LV-particulier.jpg')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/Spec_van_particulierhv.js
+++ b/screens/Spec_van_particulierhv.js
@@ -1,27 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Spec_van_particulierhv() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties 7.5 kWh Hoog</Text>
-      <Image
-        source={require('../assets/spec-HV-particulier.png')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties 7.5 kWh Hoog</Text>
+            <Image
+              source={require('../assets/spec-HV-particulier.png')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/Specificaties5kWhScreen.js
+++ b/screens/Specificaties5kWhScreen.js
@@ -1,22 +1,35 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, StyleSheet, Image } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Specificaties5kWhScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Specificaties 5 kWh Batterij</Text>
-      <Image
-        source={require('../assets/5-KWH-SPECIFICATIES.jpg')} // pas dit aan naar jouw exacte bestandsnaam
-        style={styles.image}
-        resizeMode="contain"
-      />
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
+            <Text style={styles.title}>Specificaties 5 kWh Batterij</Text>
+            <Image
+              source={require('../assets/5-KWH-SPECIFICATIES.jpg')} // pas dit aan naar jouw exacte bestandsnaam
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </View>
+        </SafeAreaView>
+      </ScreenBackground>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#fff', padding: 20
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
   },
   title: {
     fontSize: 20, fontWeight: 'bold', marginBottom: 20

--- a/screens/SpecificatiesScreen.js
+++ b/screens/SpecificatiesScreen.js
@@ -1,22 +1,35 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, StyleSheet, Image } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function SpecificatiesScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Specificaties</Text>
-      <Image
-        source={require('../assets/5-KWH-SPECIFICATIES.jpg')} // de vaste afbeelding
-        style={styles.image}
-        resizeMode="contain"
-      />
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <View style={styles.content}>
+            <Text style={styles.title}>Specificaties</Text>
+            <Image
+              source={require('../assets/5-KWH-SPECIFICATIES.jpg')} // de vaste afbeelding
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </View>
+        </SafeAreaView>
+      </ScreenBackground>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#fff', padding: 20
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
   },
   title: {
     fontSize: 20, fontWeight: 'bold', marginBottom: 20

--- a/screens/ZakelijkAdviesHandelScreen.js
+++ b/screens/ZakelijkAdviesHandelScreen.js
@@ -42,13 +42,14 @@ export default function ZakelijkAdviesHandelScreen({ route, navigation }) {
   console.log("Navigeren naar scherm:", specificatieScreen);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>Advies - Handel op energiemarkt</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <Text style={styles.title}>Advies - Handel op energiemarkt</Text>
           <Text style={styles.info}>
             Totale energiebehoefte: {totaleBehoefte.toFixed(2)} kWh
           </Text>
@@ -68,13 +69,18 @@ export default function ZakelijkAdviesHandelScreen({ route, navigation }) {
               summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(2)} kWh. Aanbevolen oplossing: ${advies}.`,
             }}
           />
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -88,7 +94,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/ZakelijkAdviesLoadShiftingScreen.js
+++ b/screens/ZakelijkAdviesLoadShiftingScreen.js
@@ -64,13 +64,14 @@ export default function ZakelijkAdviesLoadShiftingScreen({
   console.log("Navigeren naar specificatie scherm:", specificatieScreen);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>Advies Load Shifting</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <Text style={styles.title}>Advies Load Shifting</Text>
           <Text style={styles.info}>
             Totale energiebehoefte: {totaleBehoefte.toFixed(1)} kWh
           </Text>
@@ -94,13 +95,18 @@ export default function ZakelijkAdviesLoadShiftingScreen({
               summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(1)} kWh. Aanbevolen oplossing: ${advies}.`,
             }}
           />
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -114,7 +120,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/ZakelijkAdviesNetcongestie.js
+++ b/screens/ZakelijkAdviesNetcongestie.js
@@ -55,13 +55,14 @@ export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
   console.log("Navigeren naar:", specificatieScreen);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>Advies Netcongestie</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <Text style={styles.title}>Advies Netcongestie</Text>
           <Text style={styles.text}>
             Benodigd vermogen: {totaleBehoefte.toFixed(2)} kWh
           </Text>
@@ -85,13 +86,18 @@ export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
               summary: `Benodigd vermogen: ${totaleBehoefte.toFixed(2)} kWh. Aanbevolen oplossing: ${advies}.`,
             }}
           />
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -105,7 +111,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     justifyContent: "center",

--- a/screens/ZakelijkAdviesNoodstroom.js
+++ b/screens/ZakelijkAdviesNoodstroom.js
@@ -48,13 +48,14 @@ export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
   console.log("Navigeren naar:", specificatieScreen);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>Advies Noodstroomvoorziening</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <Text style={styles.title}>Advies Noodstroomvoorziening</Text>
           <Text style={styles.result}>
             Benodigde opslagcapaciteit: {totaalKwh.toFixed(1)} kWh
           </Text>
@@ -80,13 +81,18 @@ export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
               summary: `Benodigde opslagcapaciteit: ${totaalKwh.toFixed(1)} kWh. Aanbevolen oplossing: ${advies}.`,
             }}
           />
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -100,7 +106,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/ZakelijkAdviesPeakScreen.js
+++ b/screens/ZakelijkAdviesPeakScreen.js
@@ -57,16 +57,17 @@ export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
   console.log("Navigeren naar:", specificatieScreen);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={styles.container}
-        >
-          <Text style={styles.title}>Advies op maat</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView
+            style={{ flex: 1 }}
+            contentContainerStyle={styles.scrollContent}
+          >
+            <Text style={styles.title}>Advies op maat</Text>
           <Text style={styles.info}>
             Totale energiebehoefte: {totaleBehoefte.toFixed(1)} kWh
           </Text>
@@ -90,13 +91,18 @@ export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
               summary: `Totale energiebehoefte: ${totaleBehoefte.toFixed(1)} kWh. Aanbevolen oplossing: ${advies}.`,
             }}
           />
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -110,7 +116,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     minHeight: "100%",
     padding: 24,

--- a/screens/ZakelijkAdviesScreen.js
+++ b/screens/ZakelijkAdviesScreen.js
@@ -49,13 +49,14 @@ export default function ZakelijkAdviesScreen({ navigation, route }) {
   console.log("Navigeren naar:", specificatieScreen);
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>Advies op maat</Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <Text style={styles.title}>Advies op maat</Text>
           <Text style={styles.text}>
             Benodigd vermogen: {k0.toFixed(2)} kWh
           </Text>
@@ -79,13 +80,18 @@ export default function ZakelijkAdviesScreen({ navigation, route }) {
               summary: `Benodigd vermogen: ${k0.toFixed(2)} kWh. Aanbevolen oplossing: ${advies}.`,
             }}
           />
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -98,6 +104,15 @@ const styles = StyleSheet.create({
     position: "absolute",
     width: "100%",
     height: "100%",
+  },
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    padding: 24,
+    justifyContent: "center",
+    alignItems: "center",
   },
   title: {
     fontSize: 22,

--- a/screens/ZakelijkDoelScreen.js
+++ b/screens/ZakelijkDoelScreen.js
@@ -36,15 +36,16 @@ export default function ZakelijkDoelScreen({ navigation }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={styles.container}>
-          <Text style={styles.title}>
-            Wat is het doeleinde voor de batterij?
-          </Text>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContent}>
+            <Text style={styles.title}>
+              Wat is het doeleinde voor de batterij?
+            </Text>
 
           {opties.map((optie, index) => (
             <TouchableOpacity
@@ -55,13 +56,18 @@ export default function ZakelijkDoelScreen({ navigation }) {
               <Text style={styles.buttonText}>{optie}</Text>
             </TouchableOpacity>
           ))}
-        </ScrollView>
-      </SafeAreaView>
-    </ScreenBackground>
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -75,7 +81,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     padding: 24,
     alignItems: "center",

--- a/screens/ZakelijkNoodstroomScreen.js
+++ b/screens/ZakelijkNoodstroomScreen.js
@@ -45,13 +45,14 @@ export default function ZakelijkNoodstroomScreen() {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
-          <ScrollView contentContainerStyle={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
+            <ScrollView contentContainerStyle={styles.scrollContent}>
             <Text style={styles.title}>Noodstroomvoorziening</Text>
 
             <Text style={styles.label}>Benodigde capaciteit (kWh)</Text>
@@ -73,14 +74,19 @@ export default function ZakelijkNoodstroomScreen() {
             <TouchableOpacity style={styles.button} onPress={doorgaan}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -94,7 +100,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",

--- a/screens/ZakelijkOpslagScreen.js
+++ b/screens/ZakelijkOpslagScreen.js
@@ -52,13 +52,14 @@ export default function ZakelijkOpslagScreen({ navigation }) {
   };
 
   return (
-    <ScreenBackground
-      style={styles.background}
-      imageStyle={styles.imageStyle} // 🔧 web-only tweak
-    >
-      <SafeAreaView style={{ flex: 1 }}>
-        <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
-          <ScrollView contentContainerStyle={styles.container}>
+    <View style={styles.container}>
+      <ScreenBackground
+        style={styles.background}
+        imageStyle={styles.imageStyle} // 🔧 web-only tweak
+      >
+        <SafeAreaView style={styles.safeArea}>
+          <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
+            <ScrollView contentContainerStyle={styles.scrollContent}>
             <Text style={styles.title}>Opslag van PV-opwek optimaliseren</Text>
 
             <Text style={styles.label}>Jaarlijks stroomverbruik (kWh)</Text>
@@ -94,14 +95,19 @@ export default function ZakelijkOpslagScreen({ navigation }) {
             <TouchableOpacity style={styles.button} onPress={doorgaan}>
               <Text style={styles.buttonText}>Ga verder</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </KeyboardAvoidingView>
-      </SafeAreaView>
-    </ScreenBackground>
+            </ScrollView>
+          </KeyboardAvoidingView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    position: "relative",
+  },
   background: {
     flex: 1,
     width: "100%",
@@ -115,7 +121,10 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
   },
-  container: {
+  safeArea: {
+    flex: 1,
+  },
+  scrollContent: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",

--- a/screens/spec-2-mwh.js
+++ b/screens/spec-2-mwh.js
@@ -1,26 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Specificaties209Screen() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties 2.09 MWH batterij</Text>
-      <Image
-        source={require('../assets/2.09-mwh-spec.png')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties 2.09 MWH batterij</Text>
+            <Image
+              source={require('../assets/2.09-mwh-spec.png')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/spec-232-kwh.js
+++ b/screens/spec-232-kwh.js
@@ -1,27 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Specificaties232Screen() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties 232 kWh batterij</Text>
-      <Image
-        source={require('../assets/232-kwh-spec.png')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties 232 kWh batterij</Text>
+            <Image
+              source={require('../assets/232-kwh-spec.png')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/spec-5-mwh.js
+++ b/screens/spec-5-mwh.js
@@ -1,26 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Specificaties501Screen() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties 5.01 MWH batterij</Text>
-      <Image
-        source={require('../assets/5.01-mwh-spec.png')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties 5.01 MWH batterij</Text>
+            <Image
+              source={require('../assets/5.01-mwh-spec.png')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/spec-64-kwh.js
+++ b/screens/spec-64-kwh.js
@@ -1,26 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Specificaties64Screen() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties 64 kWh batterij</Text>
-      <Image
-        source={require('../assets/64-kwh-spec.png')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties 64 kWh batterij</Text>
+            <Image
+              source={require('../assets/64-kwh-spec.png')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/spec-96-kwh.js
+++ b/screens/spec-96-kwh.js
@@ -1,26 +1,31 @@
 import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { View, Text, Image, StyleSheet, ScrollView } from 'react-native';
+import ScreenBackground from '../components/ScreenBackground';
 
 export default function Specificaties96Screen() {
   return (
-    <ScrollView contentContainerStyle={styles.container}>
-      <Text style={styles.title}>Specificaties 96 kWh batterij</Text>
-      <Image
-        source={require('../assets/96-kwh-spec.png')}
-        style={styles.image}
-        resizeMode="contain"
-      />
-    </ScrollView>
+    <View style={styles.container}>
+      <ScreenBackground>
+        <SafeAreaView style={styles.safeArea}>
+          <ScrollView contentContainerStyle={styles.scrollContainer}>
+            <Text style={styles.title}>Specificaties 96 kWh batterij</Text>
+            <Image
+              source={require('../assets/96-kwh-spec.png')}
+              style={styles.image}
+              resizeMode="contain"
+            />
+          </ScrollView>
+        </SafeAreaView>
+      </ScreenBackground>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexGrow: 1,
-    backgroundColor: '#fff',
-    padding: 24,
-    alignItems: 'center',
-  },
+  container: { flex: 1, position: 'relative' },
+  safeArea: { flex: 1 },
+  scrollContainer: { flexGrow: 1, padding: 24, alignItems: 'center' },
   title: {
     fontSize: 22,
     fontWeight: 'bold',


### PR DESCRIPTION
## Summary
- wrap every remaining screen component in the shared Step1-style `<View>`/`ScreenBackground`/`SafeAreaView` structure for consistent backgrounds
- normalize safe-area handling by switching all screens to `react-native-safe-area-context` and adding shared `container`/`safeArea` styles
- preserve existing screen content while renaming inner layout wrappers (e.g. `content`, `scrollContent`) so business logic and styling stay intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690b9a3e2010832c8303712cff9baac9