### PR TITLE
Standardize full-bleed backgrounds across business and advice screens

### DIFF
--- a/screens/Advies10Hoog.js
+++ b/screens/Advies10Hoog.js
@@ -59,7 +59,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -94,6 +93,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/Advies10Laag.js
+++ b/screens/Advies10Laag.js
@@ -59,7 +59,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -94,6 +93,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/Advies12_5Hoog.js
+++ b/screens/Advies12_5Hoog.js
@@ -58,7 +58,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -93,6 +92,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/Advies15Hoog.js
+++ b/screens/Advies15Hoog.js
@@ -58,7 +58,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -93,6 +92,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/Advies17_5Hoog.js
+++ b/screens/Advies17_5Hoog.js
@@ -58,7 +58,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -93,6 +92,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/Advies20Hoog.js
+++ b/screens/Advies20Hoog.js
@@ -58,7 +58,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -93,6 +92,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/Advies5kWhScreen.js
+++ b/screens/Advies5kWhScreen.js
@@ -57,7 +57,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -93,6 +92,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/Advies7_5Hoog.js
+++ b/screens/Advies7_5Hoog.js
@@ -59,7 +59,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -94,6 +93,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#3eaf4f",
     borderRadius: 8,
+    alignSelf: "stretch",
+    alignItems: "center",
   },
   specButtonText: {
     color: "#fff",

--- a/screens/AdviesScreen.js
+++ b/screens/AdviesScreen.js
@@ -85,7 +85,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/EnergieHandel.js
+++ b/screens/EnergieHandel.js
@@ -47,10 +47,9 @@ export default function EnergieHandel({ navigation }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
-            <View style={styles.content}>
               <Text style={styles.title}>Handel op de energiemarkt</Text>
 
             <Text style={styles.label}>Gecontracteerd vermogen (kW)</Text>
@@ -102,7 +101,6 @@ export default function EnergieHandel({ navigation }) {
               <TouchableOpacity style={styles.button} onPress={handleNext}>
                 <Text style={styles.buttonText}>Ga verder</Text>
               </TouchableOpacity>
-            </View>
             </ScrollView>
           </KeyboardAvoidingView>
         </SafeAreaView>
@@ -119,22 +117,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 1200,
-  },
-  content: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/EnergiehandelVraagScreen.js
+++ b/screens/EnergiehandelVraagScreen.js
@@ -53,10 +53,9 @@ export default function EnergiehandelVraagScreen({ navigation, route }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
-            <View style={styles.content}>
               <Text style={styles.title}>
                 Wilt u handelen op de energiemarkt?
               </Text>
@@ -123,7 +122,6 @@ export default function EnergiehandelVraagScreen({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-            </View>
             </ScrollView>
           </KeyboardAvoidingView>
         </SafeAreaView>
@@ -140,22 +138,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 1200,
-  },
-  content: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/Fase3ZekeringScreen.js
+++ b/screens/Fase3ZekeringScreen.js
@@ -63,7 +63,6 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/HandelNoodstroomVraagScreen.js
+++ b/screens/HandelNoodstroomVraagScreen.js
@@ -38,10 +38,9 @@ export default function HandelNoodstroomVraagScreen({ navigation, route }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
-            <View style={styles.content}>
               <Text style={styles.title}>Noodstroomvoorziening</Text>
 
             <Text style={styles.label}>Benodigde capaciteit (kWh)</Text>
@@ -67,7 +66,6 @@ export default function HandelNoodstroomVraagScreen({ navigation, route }) {
               <TouchableOpacity style={styles.button} onPress={handleNext}>
                 <Text style={styles.buttonText}>Ga verder</Text>
               </TouchableOpacity>
-            </View>
             </ScrollView>
           </KeyboardAvoidingView>
         </SafeAreaView>
@@ -84,22 +82,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 1200,
-  },
-  content: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/LoadShifting.js
+++ b/screens/LoadShifting.js
@@ -32,8 +32,7 @@ export default function LoadShifting({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -41,7 +40,7 @@ export default function LoadShifting({ navigation }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>
@@ -87,12 +86,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -122,6 +120,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/LoadShiftingEnergiehandelVraagScreen.js
+++ b/screens/LoadShiftingEnergiehandelVraagScreen.js
@@ -62,8 +62,7 @@ export default function LoadShiftingEnergiehandelVraagScreen({
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -71,7 +70,7 @@ export default function LoadShiftingEnergiehandelVraagScreen({
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>
@@ -146,12 +145,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -181,6 +179,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/LoadShiftingNoodstroomVraagScreen.js
+++ b/screens/LoadShiftingNoodstroomVraagScreen.js
@@ -40,8 +40,7 @@ export default function LoadShiftingNoodstroomVraagScreen({
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -49,7 +48,7 @@ export default function LoadShiftingNoodstroomVraagScreen({
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>
@@ -120,12 +119,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -155,6 +153,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/Netcongestie.js
+++ b/screens/Netcongestie.js
@@ -59,7 +59,7 @@ export default function Netcongestie({ navigation }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>Netcongestie Berekening</Text>
@@ -115,12 +115,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/NetcongestieEnergiehandelVraag.js
+++ b/screens/NetcongestieEnergiehandelVraag.js
@@ -49,8 +49,7 @@ export default function NetcongestieEnergiehandelVraag({ navigation, route }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -58,7 +57,7 @@ export default function NetcongestieEnergiehandelVraag({ navigation, route }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>
@@ -143,12 +142,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -178,6 +176,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/NetcongestieNoodstroomVraag.js
+++ b/screens/NetcongestieNoodstroomVraag.js
@@ -37,8 +37,7 @@ export default function NetcongestieNoodstroomVraag({ navigation, route }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -46,7 +45,7 @@ export default function NetcongestieNoodstroomVraag({ navigation, route }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>
@@ -117,12 +116,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -152,6 +150,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/NoodstroomEnergiehandelVraagScreen.js
+++ b/screens/NoodstroomEnergiehandelVraagScreen.js
@@ -46,8 +46,7 @@ export default function NoodstroomEnergiehandelVraag({ navigation, route }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -55,7 +54,7 @@ export default function NoodstroomEnergiehandelVraag({ navigation, route }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>
@@ -140,12 +139,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -175,6 +173,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/NoodstroomVraagScreen.js
+++ b/screens/NoodstroomVraagScreen.js
@@ -44,10 +44,9 @@ export default function NoodstroomVraagScreen({ navigation, route }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
-            <View style={styles.content}>
               <Text style={styles.title}>
                 Wilt u ruimte overhouden voor noodstroom?
               </Text>
@@ -100,7 +99,6 @@ export default function NoodstroomVraagScreen({ navigation, route }) {
                 </TouchableOpacity>
               </>
             )}
-            </View>
             </ScrollView>
           </KeyboardAvoidingView>
         </SafeAreaView>
@@ -117,22 +115,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
-    alignSelf: "center",
-    width: "100%",
-    maxWidth: 1200,
-  },
-  content: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/Noodstroomvoorziening.js
+++ b/screens/Noodstroomvoorziening.js
@@ -29,8 +29,7 @@ export default function Noodstroomvoorziening({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -38,7 +37,7 @@ export default function Noodstroomvoorziening({ navigation }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>Noodstroomvoorziening</Text>
@@ -82,12 +81,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -117,6 +115,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/PeakEnergieHandelVraagScreen.js
+++ b/screens/PeakEnergieHandelVraagScreen.js
@@ -47,8 +47,7 @@ export default function PeakEnergieHandelVraagScreen({ navigation, route }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
@@ -56,7 +55,7 @@ export default function PeakEnergieHandelVraagScreen({ navigation, route }) {
             keyboardVerticalOffset={80}
           >
             <ScrollView
-              contentContainerStyle={styles.scrollContent}
+              contentContainerStyle={styles.content}
               keyboardShouldPersistTaps="handled"
             >
             <Text style={styles.title}>
@@ -141,16 +140,14 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
-    backgroundColor: "transparent",
   },
   title: {
     fontSize: 22,
@@ -177,6 +174,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/PeakNoodstroomVraagScreen.js
+++ b/screens/PeakNoodstroomVraagScreen.js
@@ -36,15 +36,14 @@ export default function PeakNoodstroomVraagScreen({ navigation, route }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
             behavior={Platform.OS === "ios" ? "padding" : "height"}
             keyboardVerticalOffset={80}
           >
-            <ScrollView contentContainerStyle={styles.scrollContent}>
+            <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>
               Wilt u ruimte overhouden voor noodstroom?
             </Text>
@@ -95,12 +94,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -130,6 +128,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/PeakShavingScreen.js
+++ b/screens/PeakShavingScreen.js
@@ -62,15 +62,14 @@ export default function PeakShavingScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView
             style={{ flex: 1 }}
             behavior={Platform.OS === "ios" ? "padding" : "height"}
             keyboardVerticalOffset={80}
           >
-            <ScrollView contentContainerStyle={styles.scrollContent}>
+            <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>Peak Shaving</Text>
 
             <View style={styles.toggleContainer}>
@@ -159,12 +158,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -196,6 +194,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/PersoonsgegevensScreen.js
+++ b/screens/PersoonsgegevensScreen.js
@@ -31,11 +31,10 @@ export default function PersoonsgegevensScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
-            <ScrollView contentContainerStyle={styles.scrollContent}>
+            <ScrollView contentContainerStyle={styles.content}>
               <Text style={styles.title}>Vul je gegevens in</Text>
 
             <Text style={styles.label}>Jaarlijks stroomverbruik (kWh)</Text>
@@ -87,16 +86,14 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
-    padding: 20,
   },
   title: {
     fontSize: 22,

--- a/screens/ZakelijkAdviesHandelScreen.js
+++ b/screens/ZakelijkAdviesHandelScreen.js
@@ -43,10 +43,9 @@ export default function ZakelijkAdviesHandelScreen({ route, navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
-          <ScrollView contentContainerStyle={styles.scrollContent}>
+          <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>Advies - Handel op energiemarkt</Text>
           <Text style={styles.info}>
             Totale energiebehoefte: {totaleBehoefte.toFixed(2)} kWh
@@ -82,12 +81,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/ZakelijkAdviesLoadShiftingScreen.js
+++ b/screens/ZakelijkAdviesLoadShiftingScreen.js
@@ -65,10 +65,9 @@ export default function ZakelijkAdviesLoadShiftingScreen({
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
-          <ScrollView contentContainerStyle={styles.scrollContent}>
+          <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>Advies Load Shifting</Text>
           <Text style={styles.info}>
             Totale energiebehoefte: {totaleBehoefte.toFixed(1)} kWh
@@ -108,12 +107,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/ZakelijkAdviesNetcongestie.js
+++ b/screens/ZakelijkAdviesNetcongestie.js
@@ -56,10 +56,9 @@ export default function ZakelijkAdviesNetcongestie({ navigation, route }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
-          <ScrollView contentContainerStyle={styles.scrollContent}>
+          <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>Advies Netcongestie</Text>
           <Text style={styles.text}>
             Benodigd vermogen: {totaleBehoefte.toFixed(2)} kWh
@@ -99,12 +98,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -131,7 +129,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
-    width: "100%",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/ZakelijkAdviesNoodstroom.js
+++ b/screens/ZakelijkAdviesNoodstroom.js
@@ -49,10 +49,9 @@ export default function ZakelijkAdviesNoodstroom({ route, navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
-          <ScrollView contentContainerStyle={styles.scrollContent}>
+          <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>Advies Noodstroomvoorziening</Text>
           <Text style={styles.result}>
             Benodigde opslagcapaciteit: {totaalKwh.toFixed(1)} kWh
@@ -94,12 +93,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -127,7 +125,7 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     marginTop: 20,
     alignItems: "center",
-    width: "100%",
+    alignSelf: "stretch",
   },
   buttonText: {
     color: "#fff",

--- a/screens/ZakelijkAdviesPeakScreen.js
+++ b/screens/ZakelijkAdviesPeakScreen.js
@@ -58,12 +58,11 @@ export default function ZakelijkAdviesPeakScreen({ route, navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <ScrollView
             style={{ flex: 1 }}
-            contentContainerStyle={styles.scrollContent}
+            contentContainerStyle={styles.content}
           >
             <Text style={styles.title}>Advies op maat</Text>
           <Text style={styles.info}>
@@ -104,12 +103,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/ZakelijkAdviesScreen.js
+++ b/screens/ZakelijkAdviesScreen.js
@@ -50,10 +50,9 @@ export default function ZakelijkAdviesScreen({ navigation, route }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
-          <ScrollView contentContainerStyle={styles.scrollContent}>
+          <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>Advies op maat</Text>
           <Text style={styles.text}>
             Benodigd vermogen: {k0.toFixed(2)} kWh
@@ -93,12 +92,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
@@ -125,7 +123,7 @@ const styles = StyleSheet.create({
     padding: 14,
     borderRadius: 10,
     alignItems: "center",
-    width: "100%",
+    alignSelf: "stretch",
     marginTop: 10,
   },
   buttonText: {

--- a/screens/ZakelijkDoelScreen.js
+++ b/screens/ZakelijkDoelScreen.js
@@ -37,10 +37,9 @@ export default function ZakelijkDoelScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
-          <ScrollView contentContainerStyle={styles.scrollContent}>
+          <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>
               Wat is het doeleinde voor de batterij?
             </Text>
@@ -69,12 +68,11 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,

--- a/screens/ZakelijkOpslagScreen.js
+++ b/screens/ZakelijkOpslagScreen.js
@@ -53,11 +53,10 @@ export default function ZakelijkOpslagScreen({ navigation }) {
 
   return (
     <View style={styles.container}>
-      <ScreenBackground
-      >
+      <ScreenBackground>
         <SafeAreaView style={styles.safeArea}>
           <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
-            <ScrollView contentContainerStyle={styles.scrollContent}>
+            <ScrollView contentContainerStyle={styles.content}>
             <Text style={styles.title}>Opslag van PV-opwek optimaliseren</Text>
 
             <Text style={styles.label}>Jaarlijks stroomverbruik (kWh)</Text>
@@ -109,16 +108,14 @@ const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
   },
-  scrollContent: {
+  content: {
     flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 24,
-    paddingVertical: 24,
     alignSelf: "center",
     width: "100%",
     maxWidth: 1200,
-    padding: 20,
   },
   title: {
     fontSize: 22,


### PR DESCRIPTION
## Summary
- normalize ScreenBackground usage for business, calculator, and advice flows to ensure cover-mode backgrounds
- align SafeAreaView and content container structure to match Step2Screen conventions
- stretch primary action buttons and clean up layout props that prevented full-bleed imagery

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690c8f087134832ca412d4c74e11adc7